### PR TITLE
feat: Add change tracking to tag lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+# Omakase Ruby styling for Rails
+inherit_gem: { rubocop-rails-omakase: rubocop.yml }
+
+# ignore schema.rb
+AllCops:
+  Exclude:
+    - test/dummy/db/schema.rb
+    - test/dummy/db/secondary_schema.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in no_fly_list.gemspec
 gemspec
 
-gem 'pg'
-rails_version = ENV.fetch('RAILS_VERSION', '~> 7.2')
-gem 'mysql2'
-gem 'railties', rails_version
-gem 'shoulda-context'
-gem 'shoulda-matchers'
-gem 'sqlite3'
+gem "pg"
+rails_version = ENV.fetch("RAILS_VERSION", "~> 7.2")
+gem "mysql2"
+gem "railties", rails_version
+gem "shoulda-context"
+gem "shoulda-matchers"
+gem "sqlite3"
+gem "rubocop-rails-omakase"

--- a/lib/generators/no_fly_list/install_generator.rb
+++ b/lib/generators/no_fly_list/install_generator.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails/generators'
-require 'rails/generators/active_record'
-require 'rails/generators/named_base'
+require "rails/generators"
+require "rails/generators/active_record"
+require "rails/generators/named_base"
 
 # Usage:
 # bin/rails generate no_fly_list:application_tag
@@ -11,15 +11,15 @@ module NoFlyList
   module Generators
     class InstallGenerator < Rails::Generators::Base
       include Rails::Generators::Migration
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
-      argument :connection_name, type: :string, desc: 'The name of the database connection', default: 'primary'
+      argument :connection_name, type: :string, desc: "The name of the database connection", default: "primary"
 
       def copy_application_tag
         ensure_connection_exists
-        template 'application_tag.rb.erb', File.join('app/models', 'application_tag.rb')
-        template 'application_tagging.rb.erb', File.join('app/models', 'application_tagging.rb')
-        migration_template 'create_application_tagging_table.rb.erb', 'db/migrate/create_application_tagging_table.rb'
+        template "application_tag.rb.erb", File.join("app/models", "application_tag.rb")
+        template "application_tagging.rb.erb", File.join("app/models", "application_tagging.rb")
+        migration_template "create_application_tagging_table.rb.erb", "db/migrate/create_application_tagging_table.rb"
       end
 
       def self.next_migration_number(dirname)

--- a/lib/generators/no_fly_list/models_generator.rb
+++ b/lib/generators/no_fly_list/models_generator.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-require 'rails/generators'
-require 'rails/generators/active_record'
-require 'rails/generators/named_base'
+require "forwardable"
+require "rails/generators"
+require "rails/generators/active_record"
+require "rails/generators/named_base"
 
 module NoFlyList
   module Generators
     class ModelsGenerator < Rails::Generators::NamedBase
-      source_root File.expand_path('templates', __dir__)
+      source_root File.expand_path("templates", __dir__)
 
       def create_model_files
         return unless validate_model # Ensure it's an ActiveRecord model
 
-        template 'tagging_model.rb.erb', File.join('app/models', class_path, "#{file_name.underscore}/tagging.rb")
-        template 'tag_model.rb.erb', File.join('app/models', class_path, "#{file_name.underscore}_tag.rb")
+        template "tagging_model.rb.erb", File.join("app/models", class_path, "#{file_name.underscore}/tagging.rb")
+        template "tag_model.rb.erb", File.join("app/models", class_path, "#{file_name.underscore}_tag.rb")
       end
 
       private

--- a/lib/generators/no_fly_list/tagging_generator.rb
+++ b/lib/generators/no_fly_list/tagging_generator.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-require 'rails/generators'
-require 'rails/generators/active_record'
-require 'rails/generators/named_base'
+require "forwardable"
+require "rails/generators"
+require "rails/generators/active_record"
+require "rails/generators/named_base"
 
 module NoFlyList
   module Generators
     class TaggingGenerator < Rails::Generators::NamedBase
       include ActiveRecord::Generators::Migration
 
-      class_option :database, type: :string, default: 'primary',
-                              desc: 'Use different database for migration'
+      class_option :database, type: :string, default: "primary",
+                              desc: "Use different database for migration"
 
       def self.default_generator_root
         File.dirname(__FILE__)
@@ -19,8 +19,8 @@ module NoFlyList
 
       def create_migration_file
         ensure_model_exists
-        migration_template 'create_tagging_table.rb.erb',
-                           [db_migrate_path, "create_#{migration_name}.rb"].compact.join('/')
+        migration_template "create_tagging_table.rb.erb",
+                           [ db_migrate_path, "create_#{migration_name}.rb" ].compact.join("/")
       end
 
       def self.next_migration_number(dirname)

--- a/lib/generators/no_fly_list/templates/tag_transformer.rb
+++ b/lib/generators/no_fly_list/templates/tag_transformer.rb
@@ -18,6 +18,6 @@ module ApplicationTagTransformer
 
   # @return [String]
   def separator
-    ','
+    ","
   end
 end

--- a/lib/generators/no_fly_list/transformer_generator.rb
+++ b/lib/generators/no_fly_list/transformer_generator.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'forwardable'
-require 'rails/generators'
-require 'rails/generators/active_record'
-require 'rails/generators/named_base'
+require "forwardable"
+require "rails/generators"
+require "rails/generators/active_record"
+require "rails/generators/named_base"
 
 unless defined?(ApplicationTagTransformer)
   module NoFlyList
     module Generators
       # bin/rails g no_fly_list:transformer
       class TransformerGenerator < Rails::Generators::Base
-        source_root File.expand_path('templates', __dir__)
+        source_root File.expand_path("templates", __dir__)
         def create_tag_transformer_file
-          template 'tag_transformer.rb', File.join('app/transformers', 'application_tag_transformer.rb')
+          template "tag_transformer.rb", File.join("app/transformers", "application_tag_transformer.rb")
         end
       end
     end

--- a/lib/no_fly_list.rb
+++ b/lib/no_fly_list.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'active_record'
-require 'active_support'
-require 'active_support/rails'
-require 'active_support/core_ext/numeric/time'
-require_relative 'no_fly_list/version'
-require 'no_fly_list/railtie' if defined?(Rails)
+require "active_record"
+require "active_support"
+require "active_support/rails"
+require "active_support/core_ext/numeric/time"
+require_relative "no_fly_list/version"
+require "no_fly_list/railtie" if defined?(Rails)
 
 module NoFlyList
   extend ActiveSupport::Autoload
@@ -16,10 +16,10 @@ module NoFlyList
   # Common tagging tables
   autoload :TaggableRecord
 
-  autoload_under 'taggable_record' do
+  autoload_under "taggable_record" do
     autoload :Configuration
     autoload :Config
-    autoload_under 'taggable_record/query' do
+    autoload_under "taggable_record/query" do
       autoload :SqliteStrategy
       autoload :MysqlStrategy
       autoload :PostgresqlStrategy

--- a/lib/no_fly_list/railtie.rb
+++ b/lib/no_fly_list/railtie.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'active_record/railtie'
-require 'rails'
+require "active_record/railtie"
+require "rails"
 
 module NoFlyList
   class Railtie < Rails::Railtie # :nodoc:
     config.no_fly_list = ActiveSupport::OrderedOptions.new
-    config.no_fly_list.tag_class_name = 'ApplicationTag'
-    config.no_fly_list.tag_table_name = 'application_tags'
-    config.no_fly_list.tagging_class_name = 'ApplicationTagging'
-    config.no_fly_list.tagging_table_name = 'application_taggings'
+    config.no_fly_list.tag_class_name = "ApplicationTag"
+    config.no_fly_list.tag_table_name = "application_tags"
+    config.no_fly_list.tagging_class_name = "ApplicationTagging"
+    config.no_fly_list.tagging_table_name = "application_taggings"
 
     rake_tasks do
-      load 'no_fly_list/railties/tasks.rake'
+      load "no_fly_list/railties/tasks.rake"
     end
   end
 end

--- a/lib/no_fly_list/railties/tasks.rake
+++ b/lib/no_fly_list/railties/tasks.rake
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
 namespace :no_fly_list do
-  desc 'List all taggable records'
+  desc "List all taggable records"
   task taggable_records: :environment do
     Rails.application.eager_load!
     taggable_classes = ActiveRecord::Base.descendants.select do |klass|
-      klass.included_modules.any? { |mod| mod.in?([NoFlyList::TaggableRecord]) }
+      klass.included_modules.any? { |mod| mod.in?([ NoFlyList::TaggableRecord ]) }
     end
 
     puts "Found #{taggable_classes.size} taggable classes:\n\n"
@@ -15,11 +15,11 @@ namespace :no_fly_list do
     end
   end
 
-  desc 'List all tag records'
+  desc "List all tag records"
   task tag_records: :environment do
     Rails.application.eager_load!
     tag_classes = ActiveRecord::Base.descendants.select do |klass|
-      klass.included_modules.any? { |mod| mod.in?([NoFlyList::ApplicationTag, NoFlyList::TagRecord]) }
+      klass.included_modules.any? { |mod| mod.in?([ NoFlyList::ApplicationTag, NoFlyList::TagRecord ]) }
     end
 
     puts "Found #{tag_classes.size} tag classes:\n\n"
@@ -29,11 +29,11 @@ namespace :no_fly_list do
     end
   end
 
-  desc 'Check taggable records and their associated tables'
+  desc "Check taggable records and their associated tables"
   task check_taggable_records: :environment do
     Rails.application.eager_load!
     taggable_classes = ActiveRecord::Base.descendants.select do |klass|
-      klass.included_modules.any? { |mod| mod.in?([NoFlyList::TaggableRecord]) }
+      klass.included_modules.any? { |mod| mod.in?([ NoFlyList::TaggableRecord ]) }
     end
 
     puts "Checking #{taggable_classes.size} taggable classes:\n\n"

--- a/lib/no_fly_list/taggable_record.rb
+++ b/lib/no_fly_list/taggable_record.rb
@@ -75,8 +75,10 @@ module NoFlyList
 
       instance_variables.any? do |var|
         next unless var.to_s.match?(/_list_proxy$/)
+
         proxy = instance_variable_get(var)
         next if proxy.nil?
+
         proxy.changed?
       end
     end

--- a/lib/no_fly_list/taggable_record/config.rb
+++ b/lib/no_fly_list/taggable_record/config.rb
@@ -32,9 +32,9 @@ module NoFlyList
 
     def determine_adapter
       case taggable_class.connection.adapter_name.downcase
-      when 'postgresql'
+      when "postgresql"
         :postgresql
-      when 'mysql2'
+      when "mysql2"
         :mysql
       else
         :sqlite

--- a/lib/no_fly_list/taggable_record/configuration.rb
+++ b/lib/no_fly_list/taggable_record/configuration.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require_relative 'mutation'
-require_relative 'query'
-require_relative 'tag_setup'
+require_relative "mutation"
+require_relative "query"
+require_relative "tag_setup"
 
 module NoFlyList
   module TaggableRecord
@@ -90,11 +90,11 @@ module NoFlyList
           # Add the basic associations
           belongs_to :tag,
                      class_name: setup.tag_class_name,
-                     foreign_key: 'tag_id'
+                     foreign_key: "tag_id"
 
           belongs_to :taggable,
                      class_name: setup.taggable_klass.name,
-                     foreign_key: 'taggable_id'
+                     foreign_key: "taggable_id"
 
           include NoFlyList::TaggingRecord
         end
@@ -118,12 +118,12 @@ module NoFlyList
         # Set up the tag model associations
         setup.tag_class_name.constantize.class_eval do
           # Fix: Use 'tagging' for the join association when context is 'tag'
-          association_name = (singular_name == 'tag' ? :taggings : :"#{singular_name}_taggings")
+          association_name = (singular_name == "tag" ? :taggings : :"#{singular_name}_taggings")
 
           has_many association_name,
                    -> { where(context: singular_name) },
                    class_name: setup.tagging_class_name,
-                   foreign_key: 'tag_id',
+                   foreign_key: "tag_id",
                    dependent: :destroy
 
           # Fix: Use consistent naming for through association
@@ -137,7 +137,7 @@ module NoFlyList
         setup.tagging_class_name.constantize.class_eval do
           belongs_to :tag,
                      class_name: setup.tag_class_name,
-                     foreign_key: 'tag_id'
+                     foreign_key: "tag_id"
 
           belongs_to :taggable,
                      polymorphic: true
@@ -149,7 +149,7 @@ module NoFlyList
 
           validates :tag_id, uniqueness: {
             scope: %i[taggable_type taggable_id context],
-            message: 'has already been tagged on this record in this context'
+            message: "has already been tagged on this record in this context"
           }
         end
       end
@@ -161,7 +161,7 @@ module NoFlyList
           has_many :"#{singular_name}_taggings",
                    -> { where(context: singular_name) },
                    class_name: setup.tagging_class_name,
-                   foreign_key: 'tag_id',
+                   foreign_key: "tag_id",
                    dependent: :destroy
 
           has_many :"#{singular_name}_taggables",
@@ -173,17 +173,17 @@ module NoFlyList
         setup.tagging_class_name.constantize.class_eval do
           belongs_to :tag,
                      class_name: setup.tag_class_name,
-                     foreign_key: 'tag_id'
+                     foreign_key: "tag_id"
 
           # For local tags, we use a simple belongs_to without polymorphic
           belongs_to :taggable,
                      class_name: setup.taggable_klass.name,
-                     foreign_key: 'taggable_id'
+                     foreign_key: "taggable_id"
 
           validates :tag, :taggable, :context, presence: true
           validates :tag_id, uniqueness: {
             scope: %i[taggable_id context],
-            message: 'has already been tagged on this record in this context'
+            message: "has already been tagged on this record in this context"
           }
         end
       end
@@ -196,7 +196,7 @@ module NoFlyList
             has_many :"#{singular_name}_taggings",
                      -> { where(context: singular_name) },
                      class_name: setup.tagging_class_name,
-                     foreign_key: 'taggable_id',
+                     foreign_key: "taggable_id",
                      as: :taggable,
                      dependent: :destroy
 
@@ -217,7 +217,7 @@ module NoFlyList
             has_many :"#{singular_name}_taggings",
                      -> { where(context: singular_name) },
                      class_name: setup.tagging_class_name,
-                     foreign_key: 'taggable_id',
+                     foreign_key: "taggable_id",
                      dependent: :destroy
 
             has_many setup.context,
@@ -237,9 +237,9 @@ module NoFlyList
           define_method :create_and_set_proxy do |instance_variable_name, setup|
             tag_model = if setup.polymorphic
                           setup.tag_class_name.constantize
-                        else
+            else
                           self.class.const_get("#{self.class.name}Tag")
-                        end
+            end
 
             proxy = TaggingProxy.new(
               self,
@@ -298,9 +298,9 @@ module NoFlyList
       end
 
       def define_constant_in_namespace(const_name)
-        parts = const_name.split('::')
+        parts = const_name.split("::")
         const_name = parts.pop
-        namespace = parts.join('::').safe_constantize || Object
+        namespace = parts.join("::").safe_constantize || Object
         return if namespace.const_defined?(const_name, false)
 
         namespace.const_set(const_name, yield)

--- a/lib/no_fly_list/taggable_record/query/mysql_strategy.rb
+++ b/lib/no_fly_list/taggable_record/query/mysql_strategy.rb
@@ -40,8 +40,8 @@ module NoFlyList
               return none if tags.empty?
 
               count_function = Arel::Nodes::NamedFunction.new(
-                'COUNT',
-                [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:name]])]
+                "COUNT",
+                [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:name] ]) ]
               )
 
               query = Arel::SelectManager.new(self)
@@ -78,11 +78,11 @@ module NoFlyList
                                 .where(context: singular_name)
                                 .where(taggable_type: name)
                                 .select(:taggable_id)
-                         else
+              else
                            setup.tagging_class_name.constantize
                                 .where(context: singular_name)
                                 .select(:taggable_id)
-                         end
+              end
 
               where("#{table_name}.#{primary_key} NOT IN (?)", subquery)
             }
@@ -95,8 +95,8 @@ module NoFlyList
                 send("without_#{context}")
               else
                 Arel::Nodes::NamedFunction.new(
-                  'COUNT',
-                  [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:id]])]
+                  "COUNT",
+                  [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:id] ]) ]
                 )
 
                 # Build the query for records having exactly the tags

--- a/lib/no_fly_list/taggable_record/query/postgresql_strategy.rb
+++ b/lib/no_fly_list/taggable_record/query/postgresql_strategy.rb
@@ -40,8 +40,8 @@ module NoFlyList
               return none if tags.empty?
 
               count_function = Arel::Nodes::NamedFunction.new(
-                'COUNT',
-                [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:name]])]
+                "COUNT",
+                [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:name] ]) ]
               )
 
               query = Arel::SelectManager.new(self)
@@ -78,11 +78,11 @@ module NoFlyList
                                 .where(context: singular_name)
                                 .where(taggable_type: name)
                                 .select(:taggable_id)
-                         else
+              else
                            setup.tagging_class_name.constantize
                                 .where(context: singular_name)
                                 .select(:taggable_id)
-                         end
+              end
 
               where.not(primary_key => subquery)
             }
@@ -95,8 +95,8 @@ module NoFlyList
                 send("without_#{context}")
               else
                 Arel::Nodes::NamedFunction.new(
-                  'COUNT',
-                  [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:id]])]
+                  "COUNT",
+                  [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:id] ]) ]
                 )
 
                 # Build the query for records having exactly the tags

--- a/lib/no_fly_list/taggable_record/query/sqlite_strategy.rb
+++ b/lib/no_fly_list/taggable_record/query/sqlite_strategy.rb
@@ -40,8 +40,8 @@ module NoFlyList
               return none if tags.empty?
 
               count_function = Arel::Nodes::NamedFunction.new(
-                'COUNT',
-                [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:name]])]
+                "COUNT",
+                [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:name] ]) ]
               )
 
               query = Arel::SelectManager.new(self)
@@ -70,7 +70,7 @@ module NoFlyList
                            .pluck("#{table_name}.id")
 
               # Handle empty tagged_ids explicitly for SQLite compatibility
-              where("#{table_name}.id NOT IN (?)", tagged_ids.present? ? tagged_ids : [-1])
+              where("#{table_name}.id NOT IN (?)", tagged_ids.present? ? tagged_ids : [ -1 ])
             }
 
             # Find records without any tags
@@ -79,12 +79,12 @@ module NoFlyList
                            setup.tagging_class_name.constantize
                                 .where(context: singular_name, taggable_type: name)
                                 .select(:taggable_id)
-                         else
+              else
                            setup.tagging_class_name.constantize
                                 .where(context: singular_name)
                                 .select(:taggable_id)
-                         end
-              where('id NOT IN (?)', subquery)
+              end
+              where("id NOT IN (?)", subquery)
             }
 
             # Find records with exactly these tags
@@ -95,8 +95,8 @@ module NoFlyList
                 send("without_#{context}")
               else
                 Arel::Nodes::NamedFunction.new(
-                  'COUNT',
-                  [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:id]])]
+                  "COUNT",
+                  [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:id] ]) ]
                 )
 
                 # Build the query for records having exactly the tags
@@ -130,8 +130,8 @@ module NoFlyList
                 send("without_#{context}")
               else
                 Arel::Nodes::NamedFunction.new(
-                  'COUNT',
-                  [Arel::Nodes::NamedFunction.new('DISTINCT', [tag_table[:id]])]
+                  "COUNT",
+                  [ Arel::Nodes::NamedFunction.new("DISTINCT", [ tag_table[:id] ]) ]
                 )
 
                 # Build the query for records having exactly the tags

--- a/lib/no_fly_list/taggable_record/tag_setup.rb
+++ b/lib/no_fly_list/taggable_record/tag_setup.rb
@@ -23,9 +23,9 @@ module NoFlyList
 
       def determine_adapter
         case ActiveRecord::Base.connection.adapter_name.downcase
-        when 'postgresql'
+        when "postgresql"
           :postgresql
-        when 'mysql2'
+        when "mysql2"
           :mysql
         else
           :sqlite

--- a/lib/no_fly_list/tagging_proxy.rb
+++ b/lib/no_fly_list/tagging_proxy.rb
@@ -51,7 +51,7 @@ module NoFlyList
     end
 
     def coerce(other)
-      [other, to_a]
+      [ other, to_a ]
     end
 
     def to_ary
@@ -69,7 +69,7 @@ module NoFlyList
         model.class.transaction do
           # Always save parent first if needed
           if model.new_record? && !model.save
-            errors.add(:base, 'Failed to save parent record')
+            errors.add(:base, "Failed to save parent record")
             raise ActiveRecord::Rollback
           end
 
@@ -149,8 +149,10 @@ module NoFlyList
 
     def add(tag)
       return self if limit_reached?
+
       new_tags = transformer.parse_tags(tag)
       return self if new_tags.empty?
+
       @pending_changes = current_list + new_tags
       @pending_changes.uniq!
       self
@@ -163,7 +165,7 @@ module NoFlyList
 
     def remove(tag)
       old_list = current_list.dup
-      @pending_changes = current_list - [tag.to_s.strip]
+      @pending_changes = current_list - [ tag.to_s.strip ]
       mark_record_dirty if @pending_changes != old_list
       self
     end
@@ -240,7 +242,7 @@ module NoFlyList
 
       # Transform tags to lowercase for comparison
       normalized_changes = @pending_changes.map(&:downcase)
-      existing_tags = @tag_model.where('LOWER(name) IN (?)', normalized_changes).pluck(:name)
+      existing_tags = @tag_model.where("LOWER(name) IN (?)", normalized_changes).pluck(:name)
       missing_tags = @pending_changes - existing_tags
 
       return unless missing_tags.any?
@@ -309,6 +311,7 @@ module NoFlyList
 
     def mark_record_dirty
       return unless model.respond_to?(:changed_attributes)
+
       # We use a virtual attribute name based on the context
       # This ensures the record is marked as changed when tags are modified
       model.send(:attribute_will_change!, "#{context}_list")

--- a/lib/no_fly_list/test_helper.rb
+++ b/lib/no_fly_list/test_helper.rb
@@ -45,9 +45,9 @@ module NoFlyList
     def assert_polymorphic_tag_classes_exist(tags_klass, tagging_klass)
       # Verify they include the correct modules
       assert tags_klass.include?(NoFlyList::ApplicationTag),
-             'Polymorphic Tag should include NoFlyList::ApplicationTag'
+             "Polymorphic Tag should include NoFlyList::ApplicationTag"
       assert tagging_klass.include?(NoFlyList::ApplicationTagging),
-             'Polymorphic Tagging should include NoFlyList::ApplicationTagging'
+             "Polymorphic Tagging should include NoFlyList::ApplicationTagging"
     end
 
     def assert_local_tag_classes_exist(klass, context)

--- a/lib/no_fly_list/version.rb
+++ b/lib/no_fly_list/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module NoFlyList
-  VERSION = '0.2.1'
+  VERSION = "0.2.1"
 end

--- a/no_fly_list.gemspec
+++ b/no_fly_list.gemspec
@@ -5,8 +5,8 @@ require_relative 'lib/no_fly_list/version'
 Gem::Specification.new do |spec|
   spec.name = 'no_fly_list'
   spec.version = NoFlyList::VERSION
-  spec.authors = ['Abdelkader Boudih']
-  spec.email = ['terminale@gmail.com']
+  spec.authors = [ 'Abdelkader Boudih' ]
+  spec.email = [ 'terminale@gmail.com' ]
 
   spec.summary = 'Tagging system for ActiveRecord models'
   spec.description = 'Tagging system for ActiveRecord models inspired by the TSA'
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 3.2.0'
 
   spec.files = Dir.glob('{db,lib}/**/*', File::FNM_DOTMATCH)
-  spec.require_paths = ['lib']
+  spec.require_paths = [ 'lib' ]
   spec.metadata['rubygems_mfa_required'] = 'true'
   spec.homepage = 'https://github.com/contriboss/no_fly_list'
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -1,55 +1,55 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module NoFlyList
   class ConfigTest < ActiveSupport::TestCase
     include NoFlyList::TestHelper
 
-    test 'has correct tag contexts configured' do
+    test "has correct tag contexts configured" do
       config = Passenger._no_fly_list
 
       assert_equal %i[special_needs meal_preferences excuses].sort,
                    config.tag_contexts.keys.sort
     end
 
-    test 'special_needs context has correct configuration' do
+    test "special_needs context has correct configuration" do
       context = Passenger._no_fly_list.tag_contexts[:special_needs]
 
-      assert_equal 'Passenger', context[:taggable_class]
-      assert_equal 'PassengerTag', context[:tag_class_name]
-      assert_equal 'Passenger::Tagging', context[:tagging_class_name]
-      assert_equal 'ApplicationTagTransformer', context[:transformer]
-      refute context[:polymorphic]
-      refute context[:restrict_to_existing]
+      assert_equal "Passenger", context[:taggable_class]
+      assert_equal "PassengerTag", context[:tag_class_name]
+      assert_equal "Passenger::Tagging", context[:tagging_class_name]
+      assert_equal "ApplicationTagTransformer", context[:transformer]
+      assert_not context[:polymorphic]
+      assert_not context[:restrict_to_existing]
       assert_nil context[:limit]
     end
 
-    test 'meal_preferences context has correct configuration' do
+    test "meal_preferences context has correct configuration" do
       context = Passenger._no_fly_list.tag_contexts[:meal_preferences]
 
-      assert_equal 'Passenger', context[:taggable_class]
-      assert_equal 'PassengerTag', context[:tag_class_name]
-      assert_equal 'Passenger::Tagging', context[:tagging_class_name]
-      assert_equal 'ApplicationTagTransformer', context[:transformer]
-      refute context[:polymorphic]
+      assert_equal "Passenger", context[:taggable_class]
+      assert_equal "PassengerTag", context[:tag_class_name]
+      assert_equal "Passenger::Tagging", context[:tagging_class_name]
+      assert_equal "ApplicationTagTransformer", context[:transformer]
+      assert_not context[:polymorphic]
       assert context[:restrict_to_existing]
       assert_nil context[:limit]
     end
 
-    test 'excuses context has correct global configuration' do
+    test "excuses context has correct global configuration" do
       context = Passenger._no_fly_list.tag_contexts[:excuses]
 
-      assert_equal 'Passenger', context[:taggable_class]
-      assert_equal 'ApplicationTag', context[:tag_class_name]
-      assert_equal 'ApplicationTagging', context[:tagging_class_name]
-      assert_equal 'ApplicationTagTransformer', context[:transformer]
+      assert_equal "Passenger", context[:taggable_class]
+      assert_equal "ApplicationTag", context[:tag_class_name]
+      assert_equal "ApplicationTagging", context[:tagging_class_name]
+      assert_equal "ApplicationTagTransformer", context[:transformer]
       assert context[:polymorphic]
-      refute context[:restrict_to_existing]
+      assert_not context[:restrict_to_existing]
       assert_nil context[:limit]
     end
 
-    test 'all tag associations are properly set up' do
+    test "all tag associations are properly set up" do
       passenger = Passenger.new
 
       # Test special needs associations
@@ -73,18 +73,18 @@ module NoFlyList
 
     test "doesn't allow non-existing meal preferences" do
       passenger = Passenger.new
-      passenger.meal_preferences_list = ['imaginary_diet']
+      passenger.meal_preferences_list = [ "imaginary_diet" ]
 
-      refute passenger.valid?
+      assert_not passenger.valid?
       assert_includes passenger.errors.full_messages.to_sentence,
-                      'imaginary_diet'
+                      "imaginary_diet"
     end
 
-    test 'allows creative excuses globally' do
+    test "allows creative excuses globally" do
       passenger = Passenger.new
-      excuse = 'My pet unicorn ate my boarding pass'
+      excuse = "My pet unicorn ate my boarding pass"
 
-      passenger.excuses_list = [excuse]
+      passenger.excuses_list = [ excuse ]
       assert passenger.valid?
       passenger.save!
 
@@ -93,16 +93,16 @@ module NoFlyList
                    passenger.excuses.first.class
     end
 
-    test 'saves special needs without restrictions' do
+    test "saves special needs without restrictions" do
       passenger = Passenger.new
-      need = 'needs_time_machine_parking'
+      need = "needs_time_machine_parking"
 
-      passenger.special_needs_list = [need]
+      passenger.special_needs_list = [ need ]
       assert passenger.valid?
       passenger.save!
 
       # Should create tag in passenger-specific table
-      assert_equal 'PassengerTag', passenger.special_needs.first.class.name
+      assert_equal "PassengerTag", passenger.special_needs.first.class.name
     end
   end
 end

--- a/test/controllers/tsa_controller_test.rb
+++ b/test/controllers/tsa_controller_test.rb
@@ -1,37 +1,37 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class TsaControllerTest < ActionDispatch::IntegrationTest
   # Using passengers fixture from the provided YAML
   fixtures :passengers
 
-  test 'index returns success and data contains expected passengers' do
+  test "index returns success and data contains expected passengers" do
     get tsa_index_path
     assert_response :success
-    data = response.parsed_body['data']
-    assert_not_empty data, 'Data should not be empty'
+    data = response.parsed_body["data"]
+    assert_not_empty data, "Data should not be empty"
 
     passenger_ids = passengers(:john_doe, :jane_smith, :xenu_follower, :olga_ivanova).map(&:id)
-    returned_ids = data.map { |passenger| passenger['id'] }
+    returned_ids = data.map { |passenger| passenger["id"] }
     passenger_ids.each do |id|
       assert_includes returned_ids, id, "Data should include passenger with id #{id}"
     end
   end
 
-  test 'show returns success for existing passenger' do
+  test "show returns success for existing passenger" do
     john_doe = passengers(:john_doe)
 
     get tsa_path(john_doe.id)
     assert_response :success
-    data = response.parsed_body['data']
-    assert_equal john_doe.id, data['id'], 'Returned data should match requested passenger'
+    data = response.parsed_body["data"]
+    assert_equal john_doe.id, data["id"], "Returned data should match requested passenger"
   end
 
-  test 'set special needs and meal preferences' do
+  test "set special needs and meal preferences" do
     jane_smith = passengers(:jane_smith)
-    special_needs = 'wheelchair,visual assistance'
-    meal_preferences = ['vegetarian']
+    special_needs = "wheelchair,visual assistance"
+    meal_preferences = [ "vegetarian" ]
 
     post set_tsa_path(jane_smith.id), params: { passenger: {
       set_special_needs: special_needs,
@@ -39,18 +39,18 @@ class TsaControllerTest < ActionDispatch::IntegrationTest
     } }
 
     assert_response :success
-    data = response.parsed_body['data']
-    assert_equal special_needs, data['special_needs'], 'Special needs should be updated'
-    assert_equal meal_preferences, data['meal_preferences'], 'Meal preferences should be updated'
+    data = response.parsed_body["data"]
+    assert_equal special_needs, data["special_needs"], "Special needs should be updated"
+    assert_equal meal_preferences, data["meal_preferences"], "Meal preferences should be updated"
   end
 
-  test 'appends to special needs and meal preferences' do
+  test "appends to special needs and meal preferences" do
     john_doe = passengers(:john_doe)
-    additional_special_needs = 'hearing assistance'
-    additional_meal_preferences = 'vegan'
+    additional_special_needs = "hearing assistance"
+    additional_meal_preferences = "vegan"
 
-    john_doe.special_needs_list.add!('wheelchair')
-    john_doe.meal_preferences_list.add!('vegetarian')
+    john_doe.special_needs_list.add!("wheelchair")
+    john_doe.meal_preferences_list.add!("vegetarian")
 
     post append_tsa_path(john_doe.id), params: { passenger: {
       add_special_needs: additional_special_needs,
@@ -58,15 +58,15 @@ class TsaControllerTest < ActionDispatch::IntegrationTest
     } }
 
     assert_response :success
-    data = response.parsed_body['data']
-    assert_includes 'wheelchair,hearing assistance', data['special_needs'], 'Special needs should include added values'
-    assert_equal %w[vegetarian vegan].sort, data['meal_preferences'].sort,
-                 'Meal preferences should include added values'
+    data = response.parsed_body["data"]
+    assert_includes "wheelchair,hearing assistance", data["special_needs"], "Special needs should include added values"
+    assert_equal %w[vegetarian vegan].sort, data["meal_preferences"].sort,
+                 "Meal preferences should include added values"
   end
 
-  test 'add and then remove specific special needs and meal preferences' do
+  test "add and then remove specific special needs and meal preferences" do
     olga_ivanova = passengers(:olga_ivanova)
-    initial_special_needs = 'wheelchair, visual assistance'
+    initial_special_needs = "wheelchair, visual assistance"
     initial_meal_preferences = %w[vegetarian gluten-free]
 
     # First, add the needs and preferences
@@ -76,8 +76,8 @@ class TsaControllerTest < ActionDispatch::IntegrationTest
     } }
 
     # Then remove them
-    remove_special_needs = 'wheelchair'
-    remove_meal_preferences = 'vegetarian'
+    remove_special_needs = "wheelchair"
+    remove_meal_preferences = "vegetarian"
 
     delete remove_tsa_path(olga_ivanova.id), params: { passenger: {
       remove_special_needs: remove_special_needs,
@@ -85,16 +85,16 @@ class TsaControllerTest < ActionDispatch::IntegrationTest
     } }
 
     assert_response :success
-    data = response.parsed_body['data']
-    refute_includes data['special_needs'], remove_special_needs, 'Special needs should not include removed values'
-    refute_includes data['meal_preferences'], remove_meal_preferences,
-                    'Meal preferences should not include removed values'
+    data = response.parsed_body["data"]
+    assert_not_includes data["special_needs"], remove_special_needs, "Special needs should not include removed values"
+    assert_not_includes data["meal_preferences"], remove_meal_preferences,
+                    "Meal preferences should not include removed values"
   end
 
-  test 'destroy clears all special needs and meal preferences' do
+  test "destroy clears all special needs and meal preferences" do
     xenu_follower = passengers(:xenu_follower)
-    initial_special_needs = 'intergalactic travel'
-    initial_meal_preferences = ['alien cuisine']
+    initial_special_needs = "intergalactic travel"
+    initial_meal_preferences = [ "alien cuisine" ]
 
     # Add special needs and meal preferences first
     post append_tsa_path(xenu_follower.id), params: { passenger: {
@@ -105,8 +105,8 @@ class TsaControllerTest < ActionDispatch::IntegrationTest
     # Check they are added
     delete tsa_path(xenu_follower.id)
     assert_response :success
-    data = response.parsed_body['data']
-    assert_empty data['special_needs'], 'All special needs should be cleared'
-    assert_empty data['meal_preferences'], 'All meal preferences should be cleared'
+    data = response.parsed_body["data"]
+    assert_empty data["special_needs"], "All special needs should be cleared"
+    assert_empty data["meal_preferences"], "All meal preferences should be cleared"
   end
 end

--- a/test/dummy/Rakefile
+++ b/test/dummy/Rakefile
@@ -3,6 +3,6 @@
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
-require_relative 'config/application'
+require_relative "config/application"
 
 Rails.application.load_tasks

--- a/test/dummy/app/models/car/tagging.rb
+++ b/test/dummy/app/models/car/tagging.rb
@@ -23,7 +23,7 @@
 #  fk_rails_...  (taggable_id => cars.id)
 #
 class Car::Tagging < SecondaryRecord
-  belongs_to :taggable, class_name: 'Car', foreign_key: 'taggable_id'
-  belongs_to :tag, class_name: 'CarTag'
+  belongs_to :taggable, class_name: "Car", foreign_key: "taggable_id"
+  belongs_to :tag, class_name: "CarTag"
   include NoFlyList::TaggingRecord
 end

--- a/test/dummy/app/models/car_tag.rb
+++ b/test/dummy/app/models/car_tag.rb
@@ -14,7 +14,7 @@
 #  index_car_tags_on_name  (name) UNIQUE
 #
 class CarTag < SecondaryRecord
-  has_many :taggings, class_name: 'Car::Tagging', dependent: :destroy
-  has_many :taggables, through: :taggings, source: :taggable, source_type: 'Car'
+  has_many :taggings, class_name: "Car::Tagging", dependent: :destroy
+  has_many :taggables, through: :taggings, source: :taggable, source_type: "Car"
   include NoFlyList::TagRecord
 end

--- a/test/dummy/app/models/company.rb
+++ b/test/dummy/app/models/company.rb
@@ -15,5 +15,5 @@
 class Company < ApplicationRecord
   include NoFlyList::TaggableRecord
 
-  has_tags :industries, transformer: 'CompanyTagTransformer'
+  has_tags :industries, transformer: "CompanyTagTransformer"
 end

--- a/test/dummy/app/models/military.rb
+++ b/test/dummy/app/models/military.rb
@@ -2,6 +2,6 @@
 
 module Military
   def self.table_name_prefix
-    'military_'
+    "military_"
   end
 end

--- a/test/dummy/app/models/truck/tagging.rb
+++ b/test/dummy/app/models/truck/tagging.rb
@@ -23,9 +23,9 @@
 #  fk_rails_...  (taggable_id => trucks.id)
 #
 class Truck::Tagging < SecondaryRecord
-  self.table_name = 'truck_taggings'
+  self.table_name = "truck_taggings"
 
-  belongs_to :taggable, class_name: 'Truck', foreign_key: 'taggable_id'
-  belongs_to :tag, class_name: 'TruckTag'
+  belongs_to :taggable, class_name: "Truck", foreign_key: "taggable_id"
+  belongs_to :tag, class_name: "TruckTag"
   include NoFlyList::TaggingRecord
 end

--- a/test/dummy/app/models/truck_tag.rb
+++ b/test/dummy/app/models/truck_tag.rb
@@ -14,7 +14,7 @@
 #  index_truck_tags_on_name  (name) UNIQUE
 #
 class TruckTag < SecondaryRecord
-  has_many :taggings, class_name: 'Truck::Tagging', dependent: :destroy
-  has_many :taggables, through: :taggings, source: :taggable, source_type: 'Truck'
+  has_many :taggings, class_name: "Truck::Tagging", dependent: :destroy
+  has_many :taggables, through: :taggings, source: :taggable, source_type: "Truck"
   include NoFlyList::TagRecord
 end

--- a/test/dummy/app/transformers/application_tag_transformer.rb
+++ b/test/dummy/app/transformers/application_tag_transformer.rb
@@ -18,6 +18,6 @@ module ApplicationTagTransformer
 
   # @return [String]
   def separator
-    ','
+    ","
   end
 end

--- a/test/dummy/app/transformers/company_tag_transformer.rb
+++ b/test/dummy/app/transformers/company_tag_transformer.rb
@@ -21,6 +21,6 @@ module CompanyTagTransformer
 
   # @return [String]
   def separator
-    ';'
+    ";"
   end
 end

--- a/test/dummy/app/transformers/person_tag_transformer.rb
+++ b/test/dummy/app/transformers/person_tag_transformer.rb
@@ -21,6 +21,6 @@ module PersonTagTransformer
 
   # @return [String]
   def separator
-    '/'
+    "/"
   end
 end

--- a/test/dummy/config.ru
+++ b/test/dummy/config.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative 'config/environment'
+require_relative "config/environment"
 
 run Rails.application
 Rails.application.load_server

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require File.expand_path('boot', __dir__)
+require File.expand_path("boot", __dir__)
 
-require 'rails'
-require 'active_model/railtie'
-require 'active_record/railtie'
-require 'action_controller/railtie'
-require 'action_view/railtie'
+require "rails"
+require "active_model/railtie"
+require "active_record/railtie"
+require "action_controller/railtie"
+require "action_view/railtie"
 
 Bundler.require(*Rails.groups)
 
 module TestSystemApp
   class Application < Rails::Application
-    config.load_defaults [Rails::VERSION::MAJOR, Rails::VERSION::MINOR].join('.')
+    config.load_defaults [ Rails::VERSION::MAJOR, Rails::VERSION::MINOR ].join(".")
     config.eager_load = true
     config.serve_static_files = false
     config.public_file_server.enabled = false
-    config.public_file_server.headers = { 'Cache-Control' => 'public, max-age=3600' }
+    config.public_file_server.headers = { "Cache-Control" => "public, max-age=3600" }
     config.consider_all_requests_local       = true
     config.action_controller.perform_caching = false
     config.action_dispatch.show_exceptions = false

--- a/test/dummy/config/boot.rb
+++ b/test/dummy/config/boot.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-require 'bundler/setup'
+require "bundler/setup"

--- a/test/dummy/config/environment.rb
+++ b/test/dummy/config/environment.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Load the Rails application.
-require File.expand_path('application', __dir__)
+require File.expand_path("application", __dir__)
 
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/test/dummy/db/migrate/11_create_people.rb
+++ b/test/dummy/db/migrate/11_create_people.rb
@@ -9,8 +9,8 @@ class CreatePeople < ActiveRecord::Migration[7.2]
       t.string :email
       t.text :address
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :person_tags do |t|

--- a/test/dummy/db/migrate/12_create_companies.rb
+++ b/test/dummy/db/migrate/12_create_companies.rb
@@ -8,8 +8,8 @@ class CreateCompanies < ActiveRecord::Migration[7.2]
       t.integer :founded_year
       t.string :ceo_name
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
   end
 end

--- a/test/dummy/db/migrate/13_create_passengers.rb
+++ b/test/dummy/db/migrate/13_create_passengers.rb
@@ -7,10 +7,10 @@ class CreatePassengers < ActiveRecord::Migration[7.2]
       t.string :last_name
       t.string :passport_number
       t.string :nationality
-      t.string :religion, default: 'scientology'
-      t.string :gender, default: 'not_sure'
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.string :religion, default: "scientology"
+      t.string :gender, default: "not_sure"
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
   end
 end

--- a/test/dummy/db/migrate/14_create_carriers.rb
+++ b/test/dummy/db/migrate/14_create_carriers.rb
@@ -7,8 +7,8 @@ class CreateCarriers < ActiveRecord::Migration[7.2]
       t.string :model
       t.integer :capacity
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :military_carrier_tags do |t|

--- a/test/dummy/db/migrate/15_create_application_tagging_table.rb
+++ b/test/dummy/db/migrate/15_create_application_tagging_table.rb
@@ -4,24 +4,24 @@ class CreateApplicationTaggingTable < ActiveRecord::Migration[7.2]
   def up
     create_table :application_tags do |t|
       t.string :name, null: false, index: { unique: true }
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :application_taggings do |t|
       t.references :tag, null: false, foreign_key: { to_table: :application_tags }
       t.references :taggable, polymorphic: true, null: false
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
 
       # Add index for uniqueness and performance
       t.index %i[taggable_type taggable_id context tag_id],
               unique: true,
-              name: 'index_app_taggings_uniqueness'
+              name: "index_app_taggings_uniqueness"
 
       # Add index for faster lookups by context
-      t.index [:context]
+      t.index [ :context ]
     end
   end
 end

--- a/test/dummy/db/migrate/16_create_tagging_company.rb
+++ b/test/dummy/db/migrate/16_create_tagging_company.rb
@@ -4,16 +4,16 @@ class CreateTaggingCompany < ActiveRecord::Migration[7.2]
   def change
     create_table :company_tags, id: :bigint do |t|
       t.string :name, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :company_taggings do |t|
       t.column :taggable_id, :bigint, null: false, index: true # Change to :uuid if you are using UUIDs
       t.column :tag_id, :bigint, null: false, index: true
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     add_index :company_tags, :name, unique: true

--- a/test/dummy/db/migrate/17_create_tagging_passenger.rb
+++ b/test/dummy/db/migrate/17_create_tagging_passenger.rb
@@ -4,16 +4,16 @@ class CreateTaggingPassenger < ActiveRecord::Migration[7.2]
   def change
     create_table :passenger_tags, id: :bigint do |t|
       t.string :name, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :passenger_taggings do |t|
       t.column :taggable_id, :bigint, null: false, index: true # Change to :uuid if you are using UUIDs
       t.column :tag_id, :bigint, null: false, index: true
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     add_index :passenger_tags, :name, unique: true

--- a/test/dummy/db/secondary_migrate/21_create_cars.rb
+++ b/test/dummy/db/secondary_migrate/21_create_cars.rb
@@ -9,8 +9,8 @@ class CreateCars < ActiveRecord::Migration[7.2]
       t.string :color
       t.integer :price_cents
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
   end
 end

--- a/test/dummy/db/secondary_migrate/22_create_buses.rb
+++ b/test/dummy/db/secondary_migrate/22_create_buses.rb
@@ -8,8 +8,8 @@ class CreateBuses < ActiveRecord::Migration[7.2]
       t.string :company
       t.boolean :accessible
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
   end
 end

--- a/test/dummy/db/secondary_migrate/23_create_trucks.rb
+++ b/test/dummy/db/secondary_migrate/23_create_trucks.rb
@@ -9,8 +9,8 @@ class CreateTrucks < ActiveRecord::Migration[7.2]
       t.integer :capacity_tons
       t.string :driver_name
 
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
   end
 end

--- a/test/dummy/db/secondary_migrate/24_create_tagging_truck.rb
+++ b/test/dummy/db/secondary_migrate/24_create_tagging_truck.rb
@@ -4,16 +4,16 @@ class CreateTaggingTruck < ActiveRecord::Migration[7.2]
   def change
     create_table :truck_tags, id: :bigint do |t|
       t.string :name, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :truck_taggings do |t|
       t.column :taggable_id, :bigint, null: false, index: true # Change to :uuid if you are using UUIDs
       t.bigint :tag_id, null: false, index: true
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     add_index :truck_tags, :name, unique: true

--- a/test/dummy/db/secondary_migrate/25_create_tagging_bus.rb
+++ b/test/dummy/db/secondary_migrate/25_create_tagging_bus.rb
@@ -4,16 +4,16 @@ class CreateTaggingBus < ActiveRecord::Migration[7.2]
   def change
     create_table :bus_tags, id: :bigint do |t|
       t.string :name, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :bus_taggings do |t|
       t.column :taggable_id, :bigint, null: false, index: true # Change to :uuid if you are using UUIDs
       t.column :tag_id, :bigint, null: false, index: true
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     add_index :bus_tags, :name, unique: true

--- a/test/dummy/db/secondary_migrate/26_create_tagging_car.rb
+++ b/test/dummy/db/secondary_migrate/26_create_tagging_car.rb
@@ -4,16 +4,16 @@ class CreateTaggingCar < ActiveRecord::Migration[7.2]
   def change
     create_table :car_tags, id: :bigint do |t|
       t.string :name, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :car_taggings do |t|
       t.column :taggable_id, :bigint, null: false, index: true # Change to :uuid if you are using UUIDs
       t.column :tag_id, :bigint, null: false, index: true
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     add_index :car_tags, :name, unique: true

--- a/test/dummy/db/secondary_migrate/27_create_application_tagging_table.rb
+++ b/test/dummy/db/secondary_migrate/27_create_application_tagging_table.rb
@@ -4,24 +4,24 @@ class CreateApplicationTaggingTable < ActiveRecord::Migration[7.2]
   def up
     create_table :application_tags do |t|
       t.string :name, null: false, index: { unique: true }
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
     end
 
     create_table :application_taggings do |t|
       t.references :tag, null: false, foreign_key: { to_table: :application_tags }
       t.references :taggable, polymorphic: true, null: false
       t.string :context, null: false
-      t.timestamp :created_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
-      t.timestamp :updated_at, default: -> { 'CURRENT_TIMESTAMP' }, null: false
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
 
       # Add index for uniqueness and performance
       t.index %i[taggable_type taggable_id context tag_id],
               unique: true,
-              name: 'index_app_taggings_uniqueness'
+              name: "index_app_taggings_uniqueness"
 
       # Add index for faster lookups by context
-      t.index [:context]
+      t.index [ :context ]
     end
   end
 end

--- a/test/dummy/test/test_helper.rb
+++ b/test/dummy/test/test_helper.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-ENV['RAILS_ENV'] = 'test'
-require_relative '../config/environment'
-require 'rails/test_help'
-require 'shoulda-context'
-require 'shoulda-matchers'
+ENV["RAILS_ENV"] = "test"
+require_relative "../config/environment"
+require "rails/test_help"
+require "shoulda-context"
+require "shoulda-matchers"
 Shoulda::Matchers.configure do |config|
   config.integrate do |with|
     with.test_framework :minitest
@@ -17,9 +17,9 @@ module ActiveSupport
   class TestCase
     # Normalize SQL for test comparisons
     def normalize_sql(sql)
-      sql.gsub(/\s+/, ' ')          # Collapse multiple spaces into one
-         .gsub('( ', '(')           # Remove space after opening parenthesis
-         .gsub(' )', ')')           # Remove space before closing parenthesis
+      sql.gsub(/\s+/, " ")          # Collapse multiple spaces into one
+         .gsub("( ", "(")           # Remove space after opening parenthesis
+         .gsub(" )", ")")           # Remove space before closing parenthesis
          .strip                     # Trim leading and trailing whitespace
     end
 
@@ -29,6 +29,6 @@ module ActiveSupport
     end
   end
 end
-puts "Using #{ENV['DB_ADAPTER']} adapter" if ENV['DB_ADAPTER']
+puts "Using #{ENV['DB_ADAPTER']} adapter" if ENV["DB_ADAPTER"]
 puts "Rails version: #{Rails.version}"
 puts "Ruby version: #{RUBY_VERSION}"

--- a/test/models/application_tag_test.rb
+++ b/test/models/application_tag_test.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 class ApplicationTagTest < ActiveSupport::TestCase
 end

--- a/test/models/application_tagging_test.rb
+++ b/test/models/application_tagging_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class ApplicationTaggingTest < ActiveSupport::TestCase
   should belong_to(:tag)

--- a/test/models/bus_test.rb
+++ b/test/models/bus_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class BusTest < ActiveSupport::TestCase
   include NoFlyList::TestHelper
@@ -9,11 +9,11 @@ class BusTest < ActiveSupport::TestCase
   should have_many(:color_taggings)
   should have_many(:colors).through(:color_taggings)
 
-  test 'assert_taggable_record' do
+  test "assert_taggable_record" do
     assert_taggable_record(Bus, :colors)
   end
 
-  test 'test limit with number' do
+  test "test limit with number" do
     bus = buses(:city_express)
     bus.colors_list = %w[red green blue]
     bus.colors_list.save
@@ -25,7 +25,7 @@ class BusTest < ActiveSupport::TestCase
     proxy.save
 
     assert_not proxy.valid?
-    assert_includes proxy.errors.full_messages, 'Cannot have more than 3 tags (attempting to save 4)'
+    assert_includes proxy.errors.full_messages, "Cannot have more than 3 tags (attempting to save 4)"
     assert_equal 0, bus2.colors_list.count
   end
 end

--- a/test/models/car_test.rb
+++ b/test/models/car_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class CarTest < ActiveSupport::TestCase
   fixtures :cars
@@ -13,11 +13,11 @@ class CarTest < ActiveSupport::TestCase
   end
 
   # Basic taggable tests
-  test 'check if model is taggable' do
+  test "check if model is taggable" do
     assert_taggable_record Car, :colors, :fuel_types
   end
 
-  test 'should have proper tag associations' do
+  test "should have proper tag associations" do
     assert_respond_to @tesla, :colors
     assert_respond_to @tesla, :fuel_types
 
@@ -26,37 +26,37 @@ class CarTest < ActiveSupport::TestCase
     assert_respond_to @tesla, :fuel_types_list
   end
 
-  test 'should paint the town red (or any color really)' do
-    @tesla.colors_list = ['cherry_red']
+  test "should paint the town red (or any color really)" do
+    @tesla.colors_list = [ "cherry_red" ]
     assert @tesla.save
     @tesla.reload
 
-    assert_equal ['cherry_red'], @tesla.colors_list.to_a
+    assert_equal [ "cherry_red" ], @tesla.colors_list.to_a
   end
 
-  test 'should fuel our imagination with multiple tags' do
-    @tesla.colors_list = ['metallic_blue']
-    @tesla.fuel_types_list = ['electrons'] # Tesla's favorite food!
+  test "should fuel our imagination with multiple tags" do
+    @tesla.colors_list = [ "metallic_blue" ]
+    @tesla.fuel_types_list = [ "electrons" ] # Tesla's favorite food!
     assert @tesla.save!
     @tesla.reload
 
-    assert_equal ['metallic_blue'], @tesla.colors_list.to_a
-    assert_equal ['electrons'], @tesla.fuel_types_list.to_a
+    assert_equal [ "metallic_blue" ], @tesla.colors_list.to_a
+    assert_equal [ "electrons" ], @tesla.fuel_types_list.to_a
   end
 
-  test 'should find cars faster than you can say vrooom' do
+  test "should find cars faster than you can say vrooom" do
     # Color some cars with style
-    @tesla.colors_list = ['rainbow']
+    @tesla.colors_list = [ "rainbow" ]
     assert @tesla.save
 
-    @jaguar.colors_list = ['miami pink', 'london blue']
+    @jaguar.colors_list = [ "miami pink", "london blue" ]
     assert @jaguar.save
 
     # Rev up those queries!
-    rainbow_rides = Car.with_any_colors('rainbow')
-    spotted_speedsters = Car.with_any_colors('miami pink')
+    rainbow_rides = Car.with_any_colors("rainbow")
+    spotted_speedsters = Car.with_any_colors("miami pink")
 
-    assert_includes rainbow_rides, @tesla, 'Looks like our Tesla lost its colors in space!'
-    assert_includes spotted_speedsters, @jaguar, 'The woke Jaguar is missing - maybe it got ordinary deleted?'
+    assert_includes rainbow_rides, @tesla, "Looks like our Tesla lost its colors in space!"
+    assert_includes spotted_speedsters, @jaguar, "The woke Jaguar is missing - maybe it got ordinary deleted?"
   end
 end

--- a/test/models/company_test.rb
+++ b/test/models/company_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class CompanyTest < ActiveSupport::TestCase
   include NoFlyList::TestHelper
@@ -9,14 +9,14 @@ class CompanyTest < ActiveSupport::TestCase
   should have_many(:industry_taggings)
   should have_many(:industries).through(:industry_taggings)
 
-  test 'assert_taggable_record' do
+  test "assert_taggable_record" do
     assert_taggable_record(Company, :industries)
   end
 
-  test 'use another transformer' do
+  test "use another transformer" do
     company = companies(:ftx)
     assert company.industries.empty?
-    company.industries_list = 'Crypto; Blockchain; NFT; Mass Scam'
+    company.industries_list = "Crypto; Blockchain; NFT; Mass Scam"
     assert_equal 4, company.industries_list.size
     assert company.save
     assert_equal 4, company.industries_list.count

--- a/test/models/military/carrier_test.rb
+++ b/test/models/military/carrier_test.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 module Military
   class CarrierTest < ActiveSupport::TestCase
     include NoFlyList::TestHelper
-    fixtures 'military/carriers'
+    fixtures "military/carriers"
     attr_reader :enterprise
 
     setup do
       @enterprise = military_carriers(:uss_enterprise)
     end
 
-    test 'assert_taggable_record' do
+    test "assert_taggable_record" do
       assert_taggable_record(Carrier, :mission_types, :capabilities, :notable_features)
     end
 
@@ -25,73 +25,73 @@ module Military
     should have_many(:notable_feature_taggings)
     should have_many(:notable_features).through(:notable_feature_taggings)
 
-    test 'add and retrieve tags' do
+    test "add and retrieve tags" do
       # Add tags to the USS Enterprise (loaded from fixtures)
-      enterprise.add_mission_types(['Flagships', 'Deep-Space Explorations'])
+      enterprise.add_mission_types([ "Flagships", "Deep-Space Explorations" ])
 
-      enterprise.add_capabilities(['High Capacities', 'Technologically Advanced Systems'])
-      enterprise.add_notable_features('Historical Significances, Time Travel Capabilities')
+      enterprise.add_capabilities([ "High Capacities", "Technologically Advanced Systems" ])
+      enterprise.add_notable_features("Historical Significances, Time Travel Capabilities")
 
       # Check tag associations
-      assert_equal ['Flagships', 'Deep-Space Explorations'], enterprise.mission_types_list.to_a
-      assert_equal ['High Capacities', 'Technologically Advanced Systems'], enterprise.capabilities_list.to_a
-      assert_equal ['Historical Significances', 'Time Travel Capabilities'], enterprise.notable_features_list.to_a
-      assert_equal 'Historical Significances,Time Travel Capabilities', enterprise.notable_features_list.to_s
+      assert_equal [ "Flagships", "Deep-Space Explorations" ], enterprise.mission_types_list.to_a
+      assert_equal [ "High Capacities", "Technologically Advanced Systems" ], enterprise.capabilities_list.to_a
+      assert_equal [ "Historical Significances", "Time Travel Capabilities" ], enterprise.notable_features_list.to_a
+      assert_equal "Historical Significances,Time Travel Capabilities", enterprise.notable_features_list.to_s
     end
-    test 'remove tags' do
-      enterprise.add_mission_types(['Flagships', 'Deep-Space Explorations'])
+    test "remove tags" do
+      enterprise.add_mission_types([ "Flagships", "Deep-Space Explorations" ])
       enterprise.save
-      enterprise.remove_mission_types('Flagships')
+      enterprise.remove_mission_types("Flagships")
       enterprise.save
 
-      assert_equal ['Deep-Space Explorations'], enterprise.mission_types_list.to_a
-    end
-
-    test 'set tags' do
-      enterprise.add_mission_types(['Flagships', 'Deep-Space Explorations'])
-      enterprise.set_mission_types(['Exploratory Ships'])
-
-      enterprise.save
-      assert_equal ['Exploratory Ships'], enterprise.mission_types_list.to_a
+      assert_equal [ "Deep-Space Explorations" ], enterprise.mission_types_list.to_a
     end
 
-    test 'clear tags' do
-      enterprise.add_mission_types(['Flagships', 'Deep-Space Explorations'])
-      assert_equal ['Flagships', 'Deep-Space Explorations'], enterprise.mission_types_list.to_a
+    test "set tags" do
+      enterprise.add_mission_types([ "Flagships", "Deep-Space Explorations" ])
+      enterprise.set_mission_types([ "Exploratory Ships" ])
+
+      enterprise.save
+      assert_equal [ "Exploratory Ships" ], enterprise.mission_types_list.to_a
+    end
+
+    test "clear tags" do
+      enterprise.add_mission_types([ "Flagships", "Deep-Space Explorations" ])
+      assert_equal [ "Flagships", "Deep-Space Explorations" ], enterprise.mission_types_list.to_a
 
       enterprise.clear_mission_types
       assert_empty enterprise.mission_types_list.to_a
     end
 
-    test 'reports changes through changed_for_autosave?' do
-      refute enterprise.changed_for_autosave?
+    test "reports changes through changed_for_autosave?" do
+      assert_not enterprise.changed_for_autosave?
 
       # Add tags
-      enterprise.mission_types_list.add('Flagships')
+      enterprise.mission_types_list.add("Flagships")
       assert enterprise.changed_for_autosave?
 
       # Save changes
       enterprise.save
-      refute enterprise.changed_for_autosave?
+      assert_not enterprise.changed_for_autosave?
 
       # Add same tag again
-      enterprise.mission_types_list.add('Flagships')
-      refute enterprise.changed_for_autosave?, "Should not mark as changed when adding existing tag"
+      enterprise.mission_types_list.add("Flagships")
+      assert_not enterprise.changed_for_autosave?, "Should not mark as changed when adding existing tag"
 
       # Add new tag
-      enterprise.mission_types_list.add('Deep-Space Explorations')
+      enterprise.mission_types_list.add("Deep-Space Explorations")
       assert enterprise.changed_for_autosave?
     end
 
-    test 'autosaves changes when parent record is saved' do
-      enterprise.mission_types_list.add('Flagships')
+    test "autosaves changes when parent record is saved" do
+      enterprise.mission_types_list.add("Flagships")
       assert enterprise.changed_for_autosave?
 
       enterprise.save
 
       # Verify changes were saved
       enterprise.reload
-      assert_equal ['Flagships'], enterprise.mission_types_list.to_a
+      assert_equal [ "Flagships" ], enterprise.mission_types_list.to_a
     end
   end
 end

--- a/test/models/passenger_test.rb
+++ b/test/models/passenger_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class PassengerTest < ActiveSupport::TestCase
   fixtures :passengers, :passenger_tags
@@ -12,11 +12,11 @@ class PassengerTest < ActiveSupport::TestCase
   should have_many(:meal_preference_taggings)
   should have_many(:meal_preferences).through(:meal_preference_taggings)
 
-  test 'assert_taggable_record' do
+  test "assert_taggable_record" do
     assert_taggable_record(Passenger, :special_needs, :meal_preferences)
   end
 
-  test 'test_helper' do
+  test "test_helper" do
     assert_local_tag_classes_exist(Passenger, :special_needs)
     assert_local_tag_classes_exist(Passenger, :meadddl_preferencess)
   end
@@ -31,53 +31,53 @@ class PassengerTest < ActiveSupport::TestCase
       @john.meal_preferences_list = %w[vegan gluten_free]
       @jane.meal_preferences_list = %w[vegetarian]
       @xenu.meal_preferences_list = %w[vegan vegetarian halal]
-      [@john, @jane, @xenu].each(&:save!)
+      [ @john, @jane, @xenu ].each(&:save!)
     end
 
-    test 'with_all_meal_preferences finds passengers with all specified diets' do
+    test "with_all_meal_preferences finds passengers with all specified diets" do
       result = Passenger.with_all_meal_preferences(%w[vegan vegetarian])
-      assert_equal [@xenu].to_set, result.to_set
+      assert_equal [ @xenu ].to_set, result.to_set
 
       result = Passenger.with_all_meal_preferences(%w[vegan kosher])
       assert_empty result
     end
 
-    test 'with_any_meal_preferences finds passengers with any of specified diets' do
+    test "with_any_meal_preferences finds passengers with any of specified diets" do
       result = Passenger.with_any_meal_preferences(%w[vegan vegetarian])
-      assert_equal [@john, @jane, @xenu].to_set, result.to_set
+      assert_equal [ @john, @jane, @xenu ].to_set, result.to_set
     end
 
-    test 'with_exact_meal_preferences finds passengers with exactly specified preferences' do
+    test "with_exact_meal_preferences finds passengers with exactly specified preferences" do
       result = Passenger.with_exact_meal_preferences(%w[vegan gluten_free])
 
       assert_equal 2, @john.meal_preferences_list.count
       actual_sql = result.to_sql
 
       expected_sql = case model_adapter(Passenger)
-                     when :sqlite
+      when :sqlite
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE (passengers.id IN (SELECT \"passengers\".\"id\" FROM \"passengers\" INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name IN ('vegan', 'gluten_free')) GROUP BY \"passengers\".\"id\" HAVING (COUNT(DISTINCT passenger_tags.id) = 2))) AND (passengers.id NOT IN (SELECT \"passengers\".\"id\" FROM \"passengers\" INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name NOT IN ('vegan', 'gluten_free'))))"
-                     when :postgresql
+      when :postgresql
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE (passengers.id IN (SELECT \"passengers\".\"id\" FROM \"passengers\" INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name IN ('vegan', 'gluten_free')) GROUP BY \"passengers\".\"id\" HAVING (COUNT(DISTINCT passenger_tags.id) = 2))) AND (passengers.id NOT IN (SELECT \"passengers\".\"id\" FROM \"passengers\" INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name NOT IN ('vegan', 'gluten_free'))))"
-                     when :mysql2
+      when :mysql2
                        "SELECT `passengers`.* FROM `passengers` WHERE (passengers.id IN (SELECT `passengers`.`id` FROM `passengers` INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name IN ('vegan', 'gluten_free')) GROUP BY `passengers`.`id` HAVING (COUNT(DISTINCT passenger_tags.id) = '2'))) AND (passengers.id NOT IN (SELECT `passengers`.`id` FROM `passengers` INNER JOIN passenger_taggings ON passenger_taggings.taggable_id = passengers.id INNER JOIN passenger_tags ON passenger_tags.id = passenger_taggings.tag_id WHERE (passenger_taggings.context = 'meal_preference') AND (passenger_tags.name NOT IN ('vegan', 'gluten_free'))))"
-                     end
+      end
 
       assert_equal normalize_sql(expected_sql), normalize_sql(actual_sql)
 
-      assert_equal [@john], result.to_a
+      assert_equal [ @john ], result.to_a
     end
 
-    test 'querying with empty tag arrays' do
+    test "querying with empty tag arrays" do
       assert_empty Passenger.with_all_meal_preferences([])
       assert_empty Passenger.with_any_meal_preferences([])
       assert_equal Passenger.all.to_set, Passenger.without_any_meal_preferences([]).to_set
     end
 
-    test 'case sensitivity in queries' do
-      @john.meal_preferences_list = ['vegan']
+    test "case sensitivity in queries" do
+      @john.meal_preferences_list = [ "vegan" ]
       @john.save!
 
-      result = Passenger.with_any_meal_preferences('vegan')
+      result = Passenger.with_any_meal_preferences("vegan")
       assert_includes result, @john
     end
   end
@@ -92,20 +92,20 @@ class PassengerTest < ActiveSupport::TestCase
       @john.special_needs_list = %w[wheelchair assistance]
       @jane.special_needs_list = %w[wheelchair]
       @xenu.special_needs_list = %w[translator]
-      [@john, @jane, @xenu].each(&:save!)
+      [ @john, @jane, @xenu ].each(&:save!)
     end
 
-    test 'with_all_special_needs finds passengers with all specified needs' do
-      result = Passenger.with_all_special_needs('wheelchair')
-      assert_equal [@john, @jane].to_set, result.to_set
+    test "with_all_special_needs finds passengers with all specified needs" do
+      result = Passenger.with_all_special_needs("wheelchair")
+      assert_equal [ @john, @jane ].to_set, result.to_set
 
       result = Passenger.with_all_special_needs(%w[wheelchair assistance])
-      assert_equal [@john].to_set, result.to_set
+      assert_equal [ @john ].to_set, result.to_set
     end
 
-    test 'with_any_special_needs finds passengers with any specified needs' do
+    test "with_any_special_needs finds passengers with any specified needs" do
       result = Passenger.with_any_special_needs(%w[wheelchair translator])
-      assert_equal [@john, @jane, @xenu].to_set, result.to_set
+      assert_equal [ @john, @jane, @xenu ].to_set, result.to_set
     end
   end
 
@@ -125,7 +125,7 @@ class PassengerTest < ActiveSupport::TestCase
       @jane.special_needs_list = %w[exorcism]
       @xenu.special_needs_list = %w[translator]
 
-      [@john, @jane, @xenu].each(&:save!)
+      [ @john, @jane, @xenu ].each(&:save!)
 
       # Assert data was saved
       assert_equal 2, @john.meal_preferences_list.count
@@ -138,27 +138,27 @@ class PassengerTest < ActiveSupport::TestCase
       assert_equal 0, @olga.special_needs_list.count
     end
 
-    test 'combining multiple tag queries' do
+    test "combining multiple tag queries" do
       result = Passenger
-               .with_any_meal_preferences('vegan')
-               .with_all_special_needs('wheelchair')
+               .with_any_meal_preferences("vegan")
+               .with_all_special_needs("wheelchair")
 
       actual_sql = result.to_sql
 
       expected_sql = case model_adapter(Passenger)
-                     when :sqlite
+      when :sqlite
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE \"passengers\".\"id\" IN (SELECT DISTINCT \"passengers\".\"id\" FROM passengers INNER JOIN \"passenger_taggings\" ON \"passenger_taggings\".\"taggable_id\" = \"passengers\".\"id\" INNER JOIN \"passenger_tags\" ON \"passenger_tags\".\"id\" = \"passenger_taggings\".\"tag_id\" WHERE \"passenger_taggings\".\"context\" = 'meal_preference' AND \"passenger_tags\".\"name\" IN ('vegan')) AND \"passengers\".\"id\" IN (SELECT \"passengers\".\"id\" FROM passengers INNER JOIN \"passenger_taggings\" ON \"passenger_taggings\".\"taggable_id\" = \"passengers\".\"id\" INNER JOIN \"passenger_tags\" ON \"passenger_tags\".\"id\" = \"passenger_taggings\".\"tag_id\" WHERE \"passenger_taggings\".\"context\" = 'special_need' AND \"passenger_tags\".\"name\" IN ('wheelchair') GROUP BY \"passengers\".\"id\" HAVING COUNT(DISTINCT(\"passenger_tags\".\"name\")) = 1)"
-                     when :postgresql
+      when :postgresql
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE \"passengers\".\"id\" IN (SELECT DISTINCT \"passengers\".\"id\" FROM passengers INNER JOIN \"passenger_taggings\" ON \"passenger_taggings\".\"taggable_id\" = \"passengers\".\"id\" INNER JOIN \"passenger_tags\" ON \"passenger_tags\".\"id\" = \"passenger_taggings\".\"tag_id\" WHERE \"passenger_taggings\".\"context\" = 'meal_preference' AND \"passenger_tags\".\"name\" IN ('vegan')) AND \"passengers\".\"id\" IN (SELECT \"passengers\".\"id\" FROM passengers INNER JOIN \"passenger_taggings\" ON \"passenger_taggings\".\"taggable_id\" = \"passengers\".\"id\" INNER JOIN \"passenger_tags\" ON \"passenger_tags\".\"id\" = \"passenger_taggings\".\"tag_id\" WHERE \"passenger_taggings\".\"context\" = 'special_need' AND \"passenger_tags\".\"name\" IN ('wheelchair') GROUP BY \"passengers\".\"id\" HAVING COUNT(DISTINCT(\"passenger_tags\".\"name\")) = 1)"
-                     when :mysql2
+      when :mysql2
                        "SELECT `passengers`.* FROM `passengers` WHERE `passengers`.`id` IN (SELECT DISTINCT `passengers`.`id` FROM passengers INNER JOIN `passenger_taggings` ON `passenger_taggings`.`taggable_id` = `passengers`.`id` INNER JOIN `passenger_tags` ON `passenger_tags`.`id` = `passenger_taggings`.`tag_id` WHERE `passenger_taggings`.`context` = 'meal_preference' AND `passenger_tags`.`name` IN ('vegan')) AND `passengers`.`id` IN (SELECT `passengers`.`id` FROM passengers INNER JOIN `passenger_taggings` ON `passenger_taggings`.`taggable_id` = `passengers`.`id` INNER JOIN `passenger_tags` ON `passenger_tags`.`id` = `passenger_taggings`.`tag_id` WHERE `passenger_taggings`.`context` = 'special_need' AND `passenger_tags`.`name` IN ('wheelchair') GROUP BY `passengers`.`id` HAVING COUNT(DISTINCT(`passenger_tags`.`name`)) = 1)"
-                     end
+      end
       assert_equal normalize_sql(expected_sql), normalize_sql(actual_sql)
 
-      assert_equal [@john], result.to_a
+      assert_equal [ @john ], result.to_a
     end
 
-    test 'without_meal_preferences finds passengers with no meal preferences' do
+    test "without_meal_preferences finds passengers with no meal preferences" do
       result = Passenger.without_meal_preferences
 
       # Capture the SQL generated
@@ -166,7 +166,7 @@ class PassengerTest < ActiveSupport::TestCase
 
       # Assert the SQL structure
       expected_sql = case model_adapter(Passenger)
-                     when :sqlite
+      when :sqlite
                        <<-SQL
     SELECT "passengers".*
     FROM "passengers"
@@ -176,25 +176,25 @@ class PassengerTest < ActiveSupport::TestCase
       WHERE "passenger_taggings"."context" = 'meal_preference'
     ))
                        SQL
-                     when :postgresql
+      when :postgresql
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE \"passengers\".\"id\" NOT IN (SELECT \"passenger_taggings\".\"taggable_id\" FROM \"passenger_taggings\" WHERE \"passenger_taggings\".\"context\" = 'meal_preference')"
-                     when :mysql2
+      when :mysql2
                        "SELECT `passengers`.* FROM `passengers` WHERE (passengers.id NOT IN (SELECT `passenger_taggings`.`taggable_id` FROM `passenger_taggings` WHERE `passenger_taggings`.`context` = 'meal_preference'))"
-                     end
+      end
 
       assert_equal normalize_sql(expected_sql), normalize_sql(actual_sql)
 
       # Assert the result
-      assert_equal [@olga], result.to_a
+      assert_equal [ @olga ], result.to_a
     end
 
-    test 'without_special_needs finds passengers with no special needs' do
+    test "without_special_needs finds passengers with no special needs" do
       result = Passenger.without_special_needs
 
       actual_sql = Passenger.without_special_needs.to_sql
 
       expected_sql = case model_adapter(Passenger)
-                     when :sqlite
+      when :sqlite
                        <<-SQL
     SELECT "passengers".*
     FROM "passengers"
@@ -204,15 +204,15 @@ class PassengerTest < ActiveSupport::TestCase
       WHERE "passenger_taggings"."context" = 'special_need'
     ))
                        SQL
-                     when :postgresql
+      when :postgresql
                        "SELECT \"passengers\".* FROM \"passengers\" WHERE \"passengers\".\"id\" NOT IN (SELECT \"passenger_taggings\".\"taggable_id\" FROM \"passenger_taggings\" WHERE \"passenger_taggings\".\"context\" = 'special_need')"
-                     when :mysql2
+      when :mysql2
                        "SELECT `passengers`.* FROM `passengers` WHERE (passengers.id NOT IN (SELECT `passenger_taggings`.`taggable_id` FROM `passenger_taggings` WHERE `passenger_taggings`.`context` = 'special_need'))"
-                     end
+      end
 
       assert_equal normalize_sql(expected_sql), normalize_sql(actual_sql)
 
-      assert_equal [@olga], result.to_a
+      assert_equal [ @olga ], result.to_a
     end
   end
 end

--- a/test/models/person_test.rb
+++ b/test/models/person_test.rb
@@ -1,27 +1,27 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class PersonTest < ActiveSupport::TestCase
   include NoFlyList::TestHelper
 
   fixtures :people, :person_tags
 
-  test 'assert_taggable_record' do
+  test "assert_taggable_record" do
     assert_taggable_record(Person, :pronouns)
   end
 
   should have_many(:pronoun_taggings)
   should have_many(:pronouns).through(:pronoun_taggings)
 
-  test 'pronoun addition validation' do
+  test "pronoun addition validation" do
     person = people(:john_doe)
     pronouns_list = person.pronouns_list
 
     assert_equal 0, person.pronouns.count
 
     # Add valid pronoun
-    pronouns_list.add('he')
+    pronouns_list.add("he")
     assert pronouns_list.save
 
     # Validate pronoun list count
@@ -29,27 +29,27 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal 1, pronouns_list.size
 
     # Attempt to add invalid pronoun
-    pronouns_list.add('where')
-    refute pronouns_list.save
+    pronouns_list.add("where")
+    assert_not pronouns_list.save
 
     # Confirm invalid pronoun rejection
     assert_equal 1, pronouns_list.count
-    assert_equal 'The following tags do not exist: where', pronouns_list.errors.full_messages.first
+    assert_equal "The following tags do not exist: where", pronouns_list.errors.full_messages.first
   end
 
-  test 'restrict pronoun addition limit' do
+  test "restrict pronoun addition limit" do
     person = people(:jane_smith)
 
     assert_equal 0, person.pronouns.count
 
     # Set pronouns
-    person.pronouns_list = 'she/her'
+    person.pronouns_list = "she/her"
     assert person.pronouns_list.save
 
     # Validate pronoun list count
     assert_equal 2, person.pronouns_list.size
 
     # Print back pronouns
-    assert_equal 'she/her', person.pronouns_list.to_s
+    assert_equal "she/her", person.pronouns_list.to_s
   end
 end

--- a/test/models/truck_test.rb
+++ b/test/models/truck_test.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class TruckTest < ActiveSupport::TestCase
   include NoFlyList::TestHelper
   fixtures :trucks
-  test 'test Truck and its associations' do
+  test "test Truck and its associations" do
     assert_taggable_record(Truck, :cargo_types, :route_tags)
   end
 
@@ -15,33 +15,33 @@ class TruckTest < ActiveSupport::TestCase
   should have_many(:route_tag_taggings)
   should have_many(:route_tags).through(:route_tag_taggings)
 
-  test 'manage cargo and route tags' do
+  test "manage cargo and route tags" do
     truck = trucks(:big_hauler)
 
     # Add and manage cargo tags using bang methods
-    truck.cargo_types_list = 'hazardous_material, refrigerated_goods'
+    truck.cargo_types_list = "hazardous_material, refrigerated_goods"
     truck.cargo_types_list.save
     assert_equal 2, truck.cargo_types_list.count
 
-    truck.cargo_types_list.add!('oversized_loads')
+    truck.cargo_types_list.add!("oversized_loads")
     assert_equal 3, truck.cargo_types_list.count
 
-    truck.cargo_types_list.remove!('refrigerated_goods')
+    truck.cargo_types_list.remove!("refrigerated_goods")
     assert_equal 2, truck.cargo_types_list.count
 
     truck.cargo_types_list.clear!
     assert_equal 0, truck.cargo_types_list.count
 
     # Route Tags
-    truck.route_tags_list = 'long_haul, interstate'
+    truck.route_tags_list = "long_haul, interstate"
     assert_equal 0, truck.route_tags.count
     assert_equal 2, truck.route_tags_list.size
 
-    truck.route_tags_list.add('local_delivery')
+    truck.route_tags_list.add("local_delivery")
     assert_equal 0, truck.route_tags.count
     assert_equal 3, truck.route_tags_list.size
 
-    truck.route_tags_list.remove('interstate')
+    truck.route_tags_list.remove("interstate")
     assert_equal 0, truck.route_tags.count
     assert_equal 2, truck.route_tags_list.size
 


### PR DESCRIPTION
Currently, changes to tag lists are not tracked by ActiveRecord's dirty tracking system, which can lead to unexpected behavior when using features that rely on change detection.

This commit:
- Adds changed_for_autosave? override to TaggableRecord
- Adds change detection to TaggingProxy via changed? method
- Compares pending changes against database state to detect real changes
- Avoids marking records as changed when adding existing tags
- Integrates with ActiveRecord's autosave functionality

The changes ensure that tag list modifications are properly tracked and saved, improving reliability when used with other ActiveRecord features like callbacks and nested attributes.

Example:
  record.mission_types_list.add('New Tag')
  record.changed_for_autosave? # => true
  record.save # Persists tag changes