### PR TITLE
feat(counter-cache): Add counter support for tag contexts

### DIFF
--- a/lib/no_fly_list/taggable_record/config.rb
+++ b/lib/no_fly_list/taggable_record/config.rb
@@ -24,7 +24,8 @@ module NoFlyList
         restrict_to_existing: options.fetch(:restrict_to_existing, false),
         limit: options.fetch(:limit, nil),
         case_sensitive: options.fetch(:case_sensitive, true),
-        adapter: @adapter
+        adapter: @adapter,
+        counter_cache: options.fetch(:counter_cache, false)
       }
     end
 

--- a/lib/no_fly_list/taggable_record/configuration.rb
+++ b/lib/no_fly_list/taggable_record/configuration.rb
@@ -94,7 +94,8 @@ module NoFlyList
 
           belongs_to :taggable,
                      class_name: setup.taggable_klass.name,
-                     foreign_key: "taggable_id"
+                     foreign_key: "taggable_id",
+                     counter_cache: setup.counter_cache ? "#{setup.context}_count" : nil
 
           include NoFlyList::TaggingRecord
         end
@@ -156,12 +157,14 @@ module NoFlyList
 
       # Sets up associations for local (non-global) tags
       def setup_local_tag_associations(setup, singular_name)
+        plural_name = setup.context.to_s
         # Set up tag class associations
         setup.tag_class_name.constantize.class_eval do
           has_many :"#{singular_name}_taggings",
                    -> { where(context: singular_name) },
                    class_name: setup.tagging_class_name,
                    foreign_key: "tag_id",
+                   counter_cache: setup.counter_cache ? "#{plural_name}_count" : nil,
                    dependent: :destroy
 
           has_many :"#{singular_name}_taggables",

--- a/lib/no_fly_list/taggable_record/tag_setup.rb
+++ b/lib/no_fly_list/taggable_record/tag_setup.rb
@@ -4,7 +4,7 @@ module NoFlyList
   module TaggableRecord
     class TagSetup
       attr_reader :taggable_klass, :context, :transformer, :polymorphic,
-                  :restrict_to_existing, :limit,
+                  :restrict_to_existing, :limit, :counter_cache,
                   :tag_class_name, :tagging_class_name, :adapter
 
       def initialize(taggable_klass, context, options = {})
@@ -13,6 +13,8 @@ module NoFlyList
         @transformer = options.fetch(:transformer, ApplicationTagTransformer)
         @polymorphic = options.fetch(:polymorphic, false)
         @restrict_to_existing = options.fetch(:restrict_to_existing, false)
+        @counter_cache = options.fetch(:counter_cache, false)
+        @counter_cache_column = "#{context}_count"
         @limit = options.fetch(:limit, nil)
         @tag_class_name = determine_tag_class_name(taggable_klass, options)
         @tagging_class_name = determine_tagging_class_name(taggable_klass, options)

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -9,7 +9,7 @@ module NoFlyList
     test "has correct tag contexts configured" do
       config = Passenger._no_fly_list
 
-      assert_equal %i[special_needs meal_preferences excuses].sort,
+      assert_equal %i[dietary_requirements special_needs meal_preferences excuses].sort,
                    config.tag_contexts.keys.sort
     end
 

--- a/test/counter_cache_test.rb
+++ b/test/counter_cache_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class CounterCacheTest < ActiveSupport::TestCase
+  fixtures :passengers
+  include NoFlyList::TestHelper
+
+  def test_multiple_counters_increment
+    passenger = passengers(:john_doe)
+    assert_equal 0, passenger.special_needs_count
+    assert_equal 0, passenger.dietary_requirements_count
+
+    passenger.special_needs_list.add("wheelchair")
+    passenger.dietary_requirements_list.add("halal")
+    passenger.save!
+    passenger.reload
+
+    assert_equal 1, passenger.special_needs_count
+    assert_equal 1, passenger.dietary_requirements_count
+  end
+
+  def test_independent_counter_operations
+    passenger = passengers(:jane_smith)
+
+    passenger.special_needs_list.add("wheelchair", "service_animal")
+    passenger.dietary_requirements_list.add("halal")
+    passenger.save!
+    passenger.reload
+
+    assert_equal 2, passenger.special_needs_count
+    assert_equal 1, passenger.dietary_requirements_count
+
+    passenger.special_needs_list.remove("wheelchair")
+    passenger.dietary_requirements_list.add("kosher")
+    passenger.save!
+    passenger.reload
+
+    assert_equal 1, passenger.special_needs_count
+    assert_equal 2, passenger.dietary_requirements_count
+  end
+
+  def test_clearing_specific_counter
+    passenger = passengers(:olga_ivanova)
+
+    passenger.special_needs_list.add("wheelchair")
+    passenger.dietary_requirements_list.add("vegetarian", "gluten_free")
+    passenger.save!
+    passenger.reload
+
+    assert_equal 1, passenger.special_needs_count
+    assert_equal 2, passenger.dietary_requirements_count
+
+    passenger.clear_dietary_requirements
+    passenger.save!
+    passenger.reload
+
+    assert_equal 1, passenger.special_needs_count
+    assert_equal 0, passenger.dietary_requirements_count
+  end
+
+  def test_meal_preferences_without_counter
+    passenger = passengers(:xenu_follower)
+
+    passenger.special_needs_list.add("wheelchair")
+    passenger.meal_preferences_list.add("vegan")
+    passenger.save!
+    passenger.reload
+
+    assert_equal 1, passenger.special_needs_count
+    assert_equal false, passenger.respond_to?(:meal_preferences_count)
+  end
+end

--- a/test/dummy/app/models/passenger.rb
+++ b/test/dummy/app/models/passenger.rb
@@ -17,8 +17,9 @@
 class Passenger < ApplicationRecord
   include NoFlyList::TaggableRecord
 
-  has_tags :special_needs
+  has_tags :special_needs, counter_cache: true
   has_tags :meal_preferences, restrict_to_existing: true
+  has_tags :dietary_requirements, counter_cache: true
 
   # We add creative excuses to not let the passenger board the plane
   has_tags :excuses, polymorphic: true

--- a/test/dummy/db/migrate/17_create_tagging_passenger.rb
+++ b/test/dummy/db/migrate/17_create_tagging_passenger.rb
@@ -20,5 +20,7 @@ class CreateTaggingPassenger < ActiveRecord::Migration[7.2]
     add_index :passenger_taggings, %i[taggable_id tag_id], unique: true
     add_foreign_key :passenger_taggings, :passenger_tags, column: :tag_id
     add_foreign_key :passenger_taggings, :passengers, column: :taggable_id
+    add_column :passengers, :special_needs_count, :integer, default: 0, null: false
+    add_column :passengers, :dietary_requirements_count, :integer, default: 0, null: false
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -105,6 +105,8 @@ ActiveRecord::Schema[7.2].define(version: 17) do
     t.string "gender", default: "not_sure"
     t.datetime "created_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
     t.datetime "updated_at", default: -> { "CURRENT_TIMESTAMP" }, null: false
+    t.integer "special_needs_count", default: 0, null: false
+    t.integer "dietary_requirements_count", default: 0, null: false
   end
 
   create_table "people", force: :cascade do |t|


### PR DESCRIPTION
- Add counter_cache option to has_tags declarations
- Support multiple counters per model
- Handle counter updates in add/remove/clear operations
- Fix multi-tag operations in add/add! methods

Example:
has_tags :special_needs, counter_cache: true
has_tags :dietary_requirements, counter_cache: true