### PR TITLE
feat(tasks): add db schema validation tasks for tags/taggings

### DIFF
--- a/lib/no_fly_list.rb
+++ b/lib/no_fly_list.rb
@@ -32,4 +32,5 @@ module NoFlyList
   autoload :TaggingProxy
 
   autoload :TestHelper
+  autoload :TaskHelpers
 end

--- a/lib/no_fly_list/task_helpers.rb
+++ b/lib/no_fly_list/task_helpers.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+module NoFlyList
+  module TaskHelpers
+    COLORS = {
+      mysql2: "\e[38;5;33m",
+      postgresql: "\e[38;5;31m",
+      sqlite: "\e[38;5;245m",
+      reset: "\e[0m",
+      green: "\e[32m",
+      red: "\e[31m",
+      yellow: "\e[33m"
+    }.freeze
+
+    REQUIRED_COLUMNS = {
+      tag: ['name'],
+      tagging: ['tag_id', 'taggable_id', 'context']
+    }.freeze
+
+    def self.adapter_color(klass)
+      color_key = klass.connection.adapter_name.downcase.to_sym
+      COLORS[color_key] || COLORS[:sqlite]
+    end
+
+    def self.colorize(text, color)
+      "#{COLORS[color]}#{text}#{COLORS[:reset]}"
+    end
+
+    def self.check_table(klass)
+      klass.table_exists?
+      [true, "#{colorize('✓', :green)} Table exists: #{klass.table_name}"]
+    rescue StandardError => e
+      [false, "#{colorize('✗', :red)} Error: #{e.message}"]
+    end
+
+    def self.verify_columns(klass, type)
+      return unless klass.table_exists?
+
+      existing_columns = klass.column_names
+      required_columns = REQUIRED_COLUMNS[type]
+      missing_columns = required_columns - existing_columns
+
+      if missing_columns.empty?
+        "#{colorize('✓', :green)} Required columns present"
+      else
+        "#{colorize('!', :yellow)} Missing required columns: #{missing_columns.join(', ')}"
+      end
+    end
+
+    def self.format_columns(klass)
+      return unless klass.table_exists?
+      "#{colorize('✓', :green)} All columns: #{klass.column_names.join(', ')}"
+    end
+
+    def self.check_class(class_name)
+      Object.const_get(class_name)
+    rescue NameError
+      nil
+    end
+
+    def self.find_taggable_classes
+      Rails.application.eager_load!
+      ActiveRecord::Base.descendants.select do |klass|
+        klass.included_modules.any? { |mod| mod.in?([NoFlyList::TaggableRecord]) }
+      end
+    end
+
+    def self.find_tag_classes
+      Rails.application.eager_load!
+      ActiveRecord::Base.descendants.select do |klass|
+        klass.included_modules.any? { |mod| mod.in?([NoFlyList::ApplicationTag, NoFlyList::TagRecord]) }
+      end
+    end
+  end
+end
+

--- a/test/rake_task_test.rb
+++ b/test/rake_task_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+require "rake"
+
+class RakeTaskTest < ActiveSupport::TestCase
+  self.use_transactional_tests = false
+
+  def setup
+    Rails.application.load_tasks
+    @original_stdout = $stdout
+    @output = StringIO.new
+    $stdout = @output
+  end
+
+  def teardown
+    $stdout = @original_stdout
+    Rake::Task.clear
+    Rails.application.load_tasks
+  end
+
+  def invoke_task(task_name)
+    @output.rewind
+    @output.truncate(0)
+    Rake::Task[task_name].reenable
+    Rake::Task[task_name].invoke
+  end
+
+  def strip_color_codes(string)
+    string.gsub(/\e\[\d+(?:;\d+)*m/, '')
+  end
+
+  test "taggable_records task lists all taggable classes" do
+    invoke_task("no_fly_list:taggable_records")
+    output = strip_color_codes(@output.string)
+
+    assert_includes output, "Car"
+    assert_includes output, "Passenger"
+    assert_includes output, "Truck"
+    assert_match /Found \d+ taggable classes:/, output
+  end
+
+  test "tag_records task lists all tag classes" do
+    invoke_task("no_fly_list:tag_records")
+    output = strip_color_codes(@output.string)
+
+    assert_includes output, "ApplicationTag"
+    assert_includes output, "PassengerTag"
+    assert_match /Found \d+ tag classes:/, output
+  end
+
+  test "check_taggable_records task validates table existence" do
+    invoke_task("no_fly_list:check_taggable_records")
+    output = strip_color_codes(@output.string)
+
+    assert_match /Checking.*Car/, output
+    assert_match /✓.*Table exists/, output
+    assert_match /✓.*Required columns present/, output
+    assert_match /✓.*All columns:/, output
+  end
+
+  test "check_taggable_records handles missing columns" do
+    Car.connection.create_table :car_tags_temp, force: true do |t|
+      t.timestamps
+    end
+
+    Car.connection.execute("INSERT INTO car_tags_temp (id, created_at, updated_at) SELECT id, created_at, updated_at FROM car_tags")
+    Car.connection.drop_table :car_tags
+    Car.connection.rename_table :car_tags_temp, :car_tags
+
+    Car.reset_column_information
+    CarTag.reset_column_information
+
+    invoke_task("no_fly_list:check_taggable_records")
+    output = strip_color_codes(@output.string)
+
+    assert_match /!.*Missing required columns: name/, output
+
+    # Restore table structure
+    Car.connection.create_table :car_tags, force: true do |t|
+      t.string :name
+      t.timestamps
+    end
+    Car.reset_column_information
+    CarTag.reset_column_information
+  end
+end


### PR DESCRIPTION
Add rake tasks to inspect tagging configuration:
- `no_fly_list:taggable_records`: Lists models with tag contexts and tables
- `no_fly_list:tag_records`: Lists global/model-specific tag classes
- `no_fly_list:check_taggable_records`: Validates schema (tables/columns/contexts)

Includes color-coded output by adapter (MySQL/PostgreSQL/SQLite) and validation status indicators for schema health checks.