### PR TITLE
chore: add Rails 8.1.0.beta1 testing support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2', '3.3', '3.4']
-        rails: ['~> 7.2', '~> 8.0']
+        rails: ['~> 7.2', '~> 8.0', '~> 8.1.0.beta1']
       fail-fast: false  # Ensures that all matrix jobs continue even if one fails
     env:
       RAILS_ENV: test


### PR DESCRIPTION
## Summary
- Add Rails 8.1.0.beta1 to the CI test matrix
- Test compatibility with the upcoming Rails 8.1 release
- Ensure the gem works with latest Rails beta version

## Changes
- Updated `.github/workflows/ci.yml` to include `~> 8.1.0.beta1` in the Rails test matrix
- Tests will run against Rails 7.2, 8.0, and 8.1.0.beta1 with Ruby 3.2, 3.3, and 3.4

## Notes
This is a draft PR to verify Rails 8.1.0.beta1 compatibility in CI before merging.