### PR TITLE
chore: update Rails 8.1 to stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         ruby: ['3.2', '3.3', '3.4']
-        rails: ['~> 7.2', '~> 8.0', '~> 8.1.0.beta1']
+        rails: ['~> 7.2', '~> 8.0', '~> 8.1.0']
       fail-fast: false  # Ensures that all matrix jobs continue even if one fails
     env:
       RAILS_ENV: test


### PR DESCRIPTION
## Summary
- Update test matrix from Rails 8.1.0.beta1 to Rails 8.1.0 stable release

## Test plan
- CI will run tests against Rails 8.1.0 stable across all Ruby versions (3.2, 3.3, 3.4)
- Verify all tests pass with the stable release