### PR TITLE
ci: add Ruby 4.0 and Rails 8.2 edge to test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,14 @@ jobs:
     name: Ruby ${{ matrix.ruby }} @ Rails ${{ matrix.rails }}
     strategy:
       matrix:
-        ruby: ['3.2', '3.3', '3.4']
+        ruby: ['3.2', '3.4', '4.0']
         rails: ['~> 7.2', '~> 8.0', '~> 8.1.0']
+        exclude:
+          - ruby: '4.0'
+            rails: '~> 7.2'
+        include:
+          - ruby: '4.0'
+            rails: 'edge'
       fail-fast: false  # Ensures that all matrix jobs continue even if one fails
     env:
       RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -8,9 +8,14 @@ gemspec
 gem "pg"
 rails_version = ENV.fetch("RAILS_VERSION", "~> 8.0")
 gem "mysql2"
-gem "railties", rails_version
+if rails_version == "edge"
+  gem "railties", github: "rails/rails", branch: "main"
+  gem "activerecord", github: "rails/rails", branch: "main"
+else
+  gem "railties", rails_version
+end
 # shoulda-context has compatibility issues with Rails 8.1+
-gem "shoulda-context", "~> 2.0" unless rails_version.match?(/8\.1/)
+gem "shoulda-context", "~> 2.0" unless rails_version.match?(/8\.[12]|edge/)
 gem "shoulda-matchers"
 gem "sqlite3"
 gem "simplecov", require: false


### PR DESCRIPTION
- Test Ruby 3.2, 3.4, 4.0 (drop 3.3)
- Add Rails edge (main branch) to matrix
- Exclude Ruby 4.0 + Rails 7.2 combination