### PR TITLE
fix: support STI models with explicit tag_class_name option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ end
 # shoulda-context has compatibility issues with Rails 8.1+
 gem "shoulda-context", "~> 2.0" unless rails_version.match?(/8\.[12]|edge/)
 gem "shoulda-matchers"
+gem "minitest", "~> 5.0"
 gem "sqlite3"
 gem "simplecov", require: false
 gem "rubocop-rails-omakase"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,30 @@ end
 article.topics_list = "Rails | API"  # Stored as ["rails", "api"]
 ```
 
+### Single Table Inheritance (STI)
+
+For STI models, subclasses must explicitly specify the parent's tag and tagging classes:
+
+```ruby
+class Vehicle < ApplicationRecord
+  include NoFlyList::TaggableRecord
+
+  has_tags :features
+end
+
+class Bicycle < Vehicle
+  has_tags :terrain_types, tag_class_name: "VehicleTag", tagging_class_name: "Vehicle::Tagging"
+end
+
+class Motorcycle < Vehicle
+  has_tags :engine_types, tag_class_name: "VehicleTag", tagging_class_name: "Vehicle::Tagging"
+end
+```
+
+All subclasses share the same `vehicle_tags` and `vehicle_taggings` tables.
+
+Due to the metaprogramming nature of `has_tags` and the wide range of Rails versions supported (7.2 through 8.2+), automatic STI detection is intentionally avoided. Explicit `tag_class_name` and `tagging_class_name` options on subclasses keep the configuration predictable across Rails upgrades — your STI setup will work the same way on Rails 7.2 as it does on 8.2, with no hidden behavior changes. Without these options, the library would generate non-existent classes like `BicycleTag` and `Bicycle::Tagging`.
+
 ## Testing Support
 
 The gem includes test helpers:

--- a/lib/no_fly_list/taggable_record/configuration.rb
+++ b/lib/no_fly_list/taggable_record/configuration.rb
@@ -82,8 +82,6 @@ module NoFlyList
 
       # Creates a new tagging class with appropriate configuration
       def create_tagging_class(setup, base_class)
-        setup.context.to_s.singularize
-
         Class.new(base_class) do
           self.table_name = "#{setup.taggable_klass.table_name.singularize}_taggings"
 
@@ -173,21 +171,26 @@ module NoFlyList
         end
 
         # Set up tagging class associations
-        setup.tagging_class_name.constantize.class_eval do
-          belongs_to :tag,
-                     class_name: setup.tag_class_name,
-                     foreign_key: "tag_id"
+        # Guard belongs_to to prevent STI subclasses from overwriting
+        # the base class association on a shared tagging class
+        tagging_klass = setup.tagging_class_name.constantize
+        existing_taggable = tagging_klass.reflect_on_association(:taggable)
+        if existing_taggable.nil? || existing_taggable.class_name == setup.taggable_klass.name
+          tagging_klass.class_eval do
+            belongs_to :tag,
+                       class_name: setup.tag_class_name,
+                       foreign_key: "tag_id"
 
-          # For local tags, we use a simple belongs_to without polymorphic
-          belongs_to :taggable,
-                     class_name: setup.taggable_klass.name,
-                     foreign_key: "taggable_id"
+            belongs_to :taggable,
+                       class_name: setup.taggable_klass.name,
+                       foreign_key: "taggable_id"
 
-          validates :tag, :taggable, :context, presence: true
-          validates :tag_id, uniqueness: {
-            scope: %i[taggable_id context],
-            message: "has already been tagged on this record in this context"
-          }
+            validates :tag, :taggable, :context, presence: true
+            validates :tag_id, uniqueness: {
+              scope: %i[taggable_id context],
+              message: "has already been tagged on this record in this context"
+            }
+          end
         end
       end
 
@@ -238,11 +241,7 @@ module NoFlyList
         # Define helper methods module for this context
         helper_module = Module.new do
           define_method :create_and_set_proxy do |instance_variable_name, setup|
-            tag_model = if setup.polymorphic
-                          setup.tag_class_name.constantize
-            else
-                          self.class.const_get("#{self.class.name}Tag")
-            end
+            tag_model = setup.tag_class_name.constantize
 
             proxy = TaggingProxy.new(
               self,

--- a/test/dummy/app/models/bicycle.rb
+++ b/test/dummy/app/models/bicycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Bicycle < Vehicle
+  has_tags :terrain_types, tag_class_name: "VehicleTag", tagging_class_name: "Vehicle::Tagging"
+end

--- a/test/dummy/app/models/motorcycle.rb
+++ b/test/dummy/app/models/motorcycle.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Motorcycle < Vehicle
+  has_tags :engine_types, tag_class_name: "VehicleTag", tagging_class_name: "Vehicle::Tagging"
+end

--- a/test/dummy/app/models/vehicle.rb
+++ b/test/dummy/app/models/vehicle.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: vehicles
+#
+#  id         :bigint           not null, primary key
+#  type       :string(255)      not null
+#  name       :string(255)
+#  year       :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+class Vehicle < ApplicationRecord
+  include NoFlyList::TaggableRecord
+
+  has_tags :features
+end

--- a/test/dummy/db/migrate/18_create_vehicles.rb
+++ b/test/dummy/db/migrate/18_create_vehicles.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+class CreateVehicles < ActiveRecord::Migration[7.2]
+  def change
+    create_table :vehicles do |t|
+      t.string :type, null: false
+      t.string :name
+      t.integer :year
+
+      t.timestamp :created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+      t.timestamp :updated_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
+    end
+
+    create_table :vehicle_tags do |t|
+      t.string :name, null: false
+      t.index :name, unique: true
+    end
+
+    create_table :vehicle_taggings do |t|
+      t.bigint :tag_id, null: false
+      t.foreign_key :vehicle_tags, column: :tag_id
+      t.bigint :taggable_id, null: false
+      t.foreign_key :vehicles, column: :taggable_id
+      t.string :context, null: false
+
+      t.index %i[taggable_id tag_id], name: "index_vehicle_taggings_on_taggable_id_and_tag_id", unique: true
+      t.index :tag_id, name: "index_vehicle_taggings_on_tag_id"
+      t.index :taggable_id, name: "index_vehicle_taggings_on_taggable_id"
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 17) do
+ActiveRecord::Schema[8.0].define(version: 18) do
   create_table "application_taggings", force: :cascade do |t|
     t.bigint "tag_id", null: false
     t.string "taggable_type", null: false
@@ -131,6 +131,28 @@ ActiveRecord::Schema[7.2].define(version: 17) do
     t.string "name", null: false
   end
 
+  create_table "vehicle_taggings", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "taggable_id", null: false
+    t.string "context", null: false
+    t.index ["tag_id"], name: "index_vehicle_taggings_on_tag_id"
+    t.index ["taggable_id", "tag_id"], name: "index_vehicle_taggings_on_taggable_id_and_tag_id", unique: true
+    t.index ["taggable_id"], name: "index_vehicle_taggings_on_taggable_id"
+  end
+
+  create_table "vehicle_tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.index ["name"], name: "index_vehicle_tags_on_name", unique: true
+  end
+
+  create_table "vehicles", force: :cascade do |t|
+    t.string "type", null: false
+    t.string "name"
+    t.integer "year"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   add_foreign_key "application_taggings", "application_tags", column: "tag_id"
   add_foreign_key "company_taggings", "companies", column: "taggable_id"
   add_foreign_key "company_taggings", "company_tags", column: "tag_id"
@@ -140,4 +162,6 @@ ActiveRecord::Schema[7.2].define(version: 17) do
   add_foreign_key "passenger_taggings", "passengers", column: "taggable_id"
   add_foreign_key "person_taggings", "people", column: "taggable_id"
   add_foreign_key "person_taggings", "person_tags", column: "tag_id"
+  add_foreign_key "vehicle_taggings", "vehicle_tags", column: "tag_id"
+  add_foreign_key "vehicle_taggings", "vehicles", column: "taggable_id"
 end

--- a/test/dummy/test/fixtures/vehicle_tags.yml
+++ b/test/dummy/test/fixtures/vehicle_tags.yml
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: vehicle_tags
+#
+#  id   :bigint           not null, primary key
+#  name :string(255)      not null
+#
+lightweight:
+  name: lightweight
+
+electric:
+  name: electric
+
+off_road:
+  name: off-road
+
+v_twin:
+  name: v-twin
+
+inline_four:
+  name: inline-four
+
+carbon_fiber:
+  name: carbon fiber

--- a/test/dummy/test/fixtures/vehicles.yml
+++ b/test/dummy/test/fixtures/vehicles.yml
@@ -1,0 +1,30 @@
+# == Schema Information
+#
+# Table name: vehicles
+#
+#  id         :bigint           not null, primary key
+#  type       :string(255)      not null
+#  name       :string(255)
+#  year       :integer
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+road_bike:
+  type: Bicycle
+  name: Road Master
+  year: 2024
+
+mountain_bike:
+  type: Bicycle
+  name: Trail Blazer
+  year: 2023
+
+harley:
+  type: Motorcycle
+  name: Street Glide
+  year: 2024
+
+ducati:
+  type: Motorcycle
+  name: Panigale V4
+  year: 2025

--- a/test/models/vehicle_test.rb
+++ b/test/models/vehicle_test.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VehicleTest < ActiveSupport::TestCase
+  include NoFlyList::TestHelper
+
+  fixtures :vehicles, :vehicle_tags
+
+  # Base class tagging
+  test "assert_taggable_record for Vehicle" do
+    assert_taggable_record(Vehicle, :features)
+  end
+
+  test "assert_taggable_record for Bicycle" do
+    assert_taggable_record(Bicycle, :features)
+    assert_taggable_record(Bicycle, :terrain_types)
+  end
+
+  test "assert_taggable_record for Motorcycle" do
+    assert_taggable_record(Motorcycle, :features)
+    assert_taggable_record(Motorcycle, :engine_types)
+  end
+
+  # STI subclass tagging
+  test "bicycle can have terrain_types tags" do
+    bike = vehicles(:road_bike)
+    assert_instance_of Bicycle, bike
+
+    bike.terrain_types_list.add("road", "gravel")
+    assert bike.terrain_types_list.save
+
+    assert_equal 2, bike.terrain_types_list.count
+    assert_includes bike.terrain_types_list.to_a, "road"
+    assert_includes bike.terrain_types_list.to_a, "gravel"
+  end
+
+  test "motorcycle can have engine_types tags" do
+    moto = vehicles(:harley)
+    assert_instance_of Motorcycle, moto
+
+    moto.engine_types_list.add("v-twin")
+    assert moto.engine_types_list.save
+
+    assert_equal 1, moto.engine_types_list.count
+    assert_includes moto.engine_types_list.to_a, "v-twin"
+  end
+
+  test "both STI subclasses share features from base class" do
+    bike = vehicles(:mountain_bike)
+    moto = vehicles(:ducati)
+
+    bike.features_list.add("lightweight", "carbon fiber")
+    assert bike.features_list.save
+
+    moto.features_list.add("electric", "lightweight")
+    assert moto.features_list.save
+
+    assert_equal 2, bike.features_list.count
+    assert_equal 2, moto.features_list.count
+
+    # Both share the "lightweight" tag but are independent records
+    assert_includes bike.features_list.to_a, "lightweight"
+    assert_includes moto.features_list.to_a, "lightweight"
+  end
+
+  test "STI subclass tags are scoped to their context" do
+    bike = vehicles(:road_bike)
+    moto = vehicles(:harley)
+
+    # Bicycle has terrain_types but not engine_types
+    assert_respond_to bike, :terrain_types_list
+    assert_not_respond_to bike, :engine_types_list
+
+    # Motorcycle has engine_types but not terrain_types
+    assert_respond_to moto, :engine_types_list
+    assert_not_respond_to moto, :terrain_types_list
+  end
+
+  test "tags persist correctly across STI type column" do
+    bike = vehicles(:road_bike)
+    bike.features_list.add("electric")
+    assert bike.features_list.save
+
+    # Reload via base class and verify STI type is preserved
+    reloaded = Vehicle.find(bike.id)
+    assert_instance_of Bicycle, reloaded
+    assert_equal ["electric"], reloaded.features_list.to_a
+  end
+end


### PR DESCRIPTION
- Fix const_get lookup to use setup.tag_class_name.constantize instead of self.class.const_get, honoring explicit tag_class_name option
- Guard belongs_to :taggable in setup_local_tag_associations to prevent STI subclasses from overwriting the base class association on shared tagging classes
- Add Vehicle STI test models (Bicycle, Motorcycle) with full test coverage for shared and subclass-specific tag contexts
- Pin minitest ~> 5.0 for Ruby 4.0 compatibility